### PR TITLE
Fix mri_smooth argument handling to prevent stray output file

### DIFF
--- a/R/fs-utils.R
+++ b/R/fs-utils.R
@@ -204,12 +204,19 @@ mri_smooth <- function(input_file, label, output_file, verbose, opts = NULL) {
   check_fs(abort = TRUE)
 
   fscmd <- "mris_smooth"
+  if (!is.null(opts)) {
+    fscmd <- paste(fscmd, opts)
+  }
 
-  if (!is.null(opts)) fs_cmd <- paste0(fs_cmd, opts)
-
-  cmd <- paste(fscmd, "-nw", input_file, label, output_file)
+  cmd <- paste(
+    fscmd,
+    "-nw",
+    shQuote(input_file),
+    shQuote(output_file)
+  )
 
   k <- run_cmd(cmd, verbose = verbose)
+  invisible(k)
 }
 
 


### PR DESCRIPTION
mri_smooth() was incorrectly passing the label argument to FreeSurfer's mris_smooth, causing a stray file named after the label (e.g. "1") to be created in the working directory.

This patch removes the label argument from the command, properly quotes input/output paths, and preserves the original invisible return behavior.
## Summary
`mri_smooth()` was invoking FreeSurfer `mris_smooth` with an extra `label` argument:
`mris_smooth -nw <input> <label> <output>`

On my system this caused `mris_smooth` to create a stray file named after the label
(e.g. `./1`) and prevented downstream steps from producing the expected smoothed
surface file (breaking `aseg_2_mesh()` and `make_volumetric_2_3datlas()`).

This PR updates the command to:
`mris_smooth -nw <input> <output>`
and quotes input/output paths.

## Repro
1. Run the minimal repro script (calls `ggsegExtra:::aseg_2_mesh(..., steps = 1:3, label = 1)`).
2. **Before**: a stray file named `1` appears in `getwd()`, and `surf/0001_smooth` is not created
   (later `.ply` is missing).
3. **After**: no stray `1` file is created; the smoothed surface output is written to the expected location.

## Verification
- Confirmed the full atlas build pipeline runs and produces valid meshes/plots after the fix.

## Environment
- macOS Sequoia 15.3 (arm64), R 4.4.3
- FreeSurfer 8.1.0
- ggsegExtra 1.5.33.5 (gdal branch)

Fixes #68 
