### PR TITLE
Skip ggseg3d render tests when ggseg.meshes not installed

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -42,8 +42,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install TeX Live
-        run: sudo apt-get update && sudo apt-get install -y texlive-base texlive-latex-recommended texlive-fonts-recommended texlive-extra-utils
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            texlive-base texlive-latex-recommended texlive-latex-extra \
+            texlive-fonts-recommended texlive-fonts-extra texlive-extra-utils \
+            imagemagick libmagick++-dev libgdal-dev libproj-dev libgeos-dev \
+            libudunits2-dev libglpk-dev libharfbuzz-dev libfribidi-dev
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -6,7 +6,8 @@
 #'
 #' @param detail Character. Level of detail to display:
 #'   - `"simple"` (default): Quick pass/fail overview
-#'   - `"full"`: Detailed diagnostics including [freesurfer::fs_sitrep()]
+#'   - `"full"`: Detailed diagnostics including `freesurfer::fs_sitrep()`
+#'     when available
 #'
 #' @return Invisibly returns a list with check results.
 #' @export
@@ -33,12 +34,12 @@ setup_sitrep <- function(detail = c("simple", "full")) {
 check_freesurfer <- function(detail = "simple") {
   if (!rlang::is_installed("freesurfer")) {
     cli::cli_alert_danger("freesurfer R package not installed")
-    return(FALSE)
+    return(list(available = FALSE))
   }
   has_fs <- freesurfer::have_fs()
 
   if (detail == "full") {
-    freesurfer::fs_sitrep()
+    fs_sitrep_safe()
   } else {
     if (has_fs) {
       cli::cli_alert_success("FreeSurfer")
@@ -48,6 +49,20 @@ check_freesurfer <- function(detail = "simple") {
   }
 
   list(available = has_fs)
+}
+
+
+# `fs_sitrep()` was added in freesurfer > 1.8.1 (CRAN). Call it via the
+# namespace only if the binding exists so older installs don't error.
+fs_sitrep_safe <- function() {
+  ns <- asNamespace("freesurfer")
+  if (exists("fs_sitrep", envir = ns, inherits = FALSE)) {
+    get("fs_sitrep", envir = ns)()
+  } else {
+    cli::cli_alert_info(
+      "Detailed {.pkg freesurfer} diagnostics require a newer version of the package."
+    )
+  }
 }
 
 

--- a/R/utils-snapshot.R
+++ b/R/utils-snapshot.R
@@ -20,9 +20,7 @@ process_snapshot_image <- function(
   fuzz = 10,
   skip_existing = get_skip_existing()
 ) {
-  rlang::check_installed("magick",
-    reason = "for snapshot image processing"
-  )
+  rlang::check_installed("magick", reason = "for snapshot image processing")
   if (skip_existing && file.exists(output_file)) {
     return(invisible(output_file))
   }
@@ -59,7 +57,10 @@ extract_alpha_mask <- function(
   exit_code <- system2(
     "magick",
     args = c(
-      shQuote(input_file), "-alpha", "extract", shQuote(output_file)
+      shQuote(input_file),
+      "-alpha",
+      "extract",
+      shQuote(output_file)
     ),
     stdout = FALSE,
     stderr = FALSE
@@ -211,7 +212,7 @@ check_magick <- function() {
 #' @noRd
 magick_version <- function() {
   tryCatch(
-    system2("magick", "--version", stdout = TRUE)[1],
+    system2("magick", "--version", stdout = TRUE, stderr = FALSE)[1],
     error = function(e) "",
     warning = function(w) ""
   )
@@ -260,9 +261,7 @@ get_contours <- function(
   vertex_size_limits = c(3 * 10^6, 3 * 10^7),
   verbose = get_verbose() # nolint: object_usage_linter
 ) {
-  rlang::check_installed("terra",
-    reason = "for contour extraction"
-  )
+  rlang::check_installed("terra", reason = "for contour extraction")
   mx <- terra::global(raster_object, fun = "max", na.rm = TRUE)[1, 1]
 
   if (mx < max_val) {
@@ -299,9 +298,7 @@ isolate_region <- function(
   interim_file = tempfile(),
   skip_existing = get_skip_existing()
 ) {
-  rlang::check_installed("magick",
-    reason = "for snapshot image processing"
-  )
+  rlang::check_installed("magick", reason = "for snapshot image processing")
   if (skip_existing && file.exists(output_file)) {
     return(invisible(output_file))
   }
@@ -316,7 +313,10 @@ isolate_region <- function(
     system2(
       "magick",
       args = c(
-        shQuote(interim_file), "-alpha", "extract", shQuote(output_file)
+        shQuote(interim_file),
+        "-alpha",
+        "extract",
+        shQuote(output_file)
       ),
       stdout = FALSE,
       stderr = FALSE

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -7,6 +7,7 @@ CIFTI
 CMD
 CSF
 Centerline
+Chaikin
 Colour
 Connectome
 DK
@@ -20,7 +21,9 @@ Frenet
 GH
 GIFTI
 GitLab
+Glasser
 HCL
+HCP
 ImageMagick
 LUT
 Lifebrain
@@ -29,7 +32,9 @@ MGZ
 MNI
 MRtrix
 NIfTI
+NeuroVault
 Neuromaps
+Neuroscientists
 Nx
 ORCID
 Peucker
@@ -57,10 +62,13 @@ Yeo
 abagen
 annot
 aparc
+artefacts
 aseg
+backface
 behaviour
 bibentry
 binormals
+blobby
 caudate
 centerline
 chromote
@@ -80,11 +88,14 @@ fibres
 freesurfer
 fsaverage
 furrr
+ggplot
 ggseg
 ggsegExtra
+ggsegHO
 ggsegverse
 github
 grey
+gyri
 gyrus
 gz
 hemi
@@ -95,9 +106,12 @@ labelled
 lh
 medoid
 mgz
+midline
 minimises
 mri
 mris
+neighbouring
+neighbours
 neuroimaging
 neuromapr
 neuromaps
@@ -117,6 +131,7 @@ purrr
 putamen
 quadric
 ras
+rasterisation
 rda
 renderers
 repositions
@@ -126,6 +141,7 @@ rh
 roi
 roxygen
 sagittal
+sawtooth
 segmentations
 subcortical
 summarises
@@ -141,5 +157,6 @@ visualising
 vox
 webshot
 websocket
+wholebrain
 ’
 ’s

--- a/man/setup_sitrep.Rd
+++ b/man/setup_sitrep.Rd
@@ -10,7 +10,8 @@ setup_sitrep(detail = c("simple", "full"))
 \item{detail}{Character. Level of detail to display:
 \itemize{
 \item \code{"simple"} (default): Quick pass/fail overview
-\item \code{"full"}: Detailed diagnostics including \code{\link[freesurfer:fs_sitrep]{freesurfer::fs_sitrep()}}
+\item \code{"full"}: Detailed diagnostics including \code{freesurfer::fs_sitrep()}
+when available
 }}
 }
 \value{

--- a/tests/testthat/test-atlas-cortical.R
+++ b/tests/testthat/test-atlas-cortical.R
@@ -43,6 +43,7 @@ describe("create_cortical_from_annotation", {
 
   it("can render with ggseg3d", {
     skip_if_not_installed("freesurferformats")
+    skip_if_not_installed("ggseg.meshes")
 
     annots <- test_annot_files()
     annot_files <- c(annots$lh, annots$rh)

--- a/tests/testthat/test-atlas-subcortical.R
+++ b/tests/testthat/test-atlas-subcortical.R
@@ -198,6 +198,7 @@ describe("create_subcortical_from_volume with meshes", {
   })
 
   it("can render with ggseg3d", {
+    skip_if_not_installed("ggseg.meshes")
     expect_no_error({
       p <- ggseg3d::ggseg3d(atlas = atlas, hemisphere = "subcort")
     })

--- a/tests/testthat/test-atlas-tracts.R
+++ b/tests/testthat/test-atlas-tracts.R
@@ -91,6 +91,8 @@ describe("create_tract_from_tractography", {
   })
 
   it("can render with ggseg3d", {
+    skip_if_not_installed("ggseg.meshes")
+
     tracts <- list(
       cst_left = matrix(c(1:20, rep(0, 40)), ncol = 3),
       cst_right = matrix(c(1:20, rep(1, 40)), ncol = 3)

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -1,6 +1,7 @@
 describe("integration tests", {
   it("creates atlas from labels and renders with ggseg3d", {
     skip_if_not_installed("freesurferformats")
+    skip_if_not_installed("ggseg.meshes")
 
     labels <- unlist(test_label_files())
     atlas <- create_cortical_from_labels(
@@ -19,6 +20,7 @@ describe("integration tests", {
 
   it("creates atlas from annotation and renders with ggseg3d", {
     skip_if_not_installed("freesurferformats")
+    skip_if_not_installed("ggseg.meshes")
 
     annots <- test_annot_files()
     annot_files <- c(annots$lh, annots$rh)

--- a/tests/testthat/test-sitrep.R
+++ b/tests/testthat/test-sitrep.R
@@ -2,9 +2,9 @@ describe("setup_sitrep", {
   it("returns list of results invisibly", {
     local_mocked_bindings(
       have_fs = function() TRUE,
-      fs_sitrep = function() invisible(NULL),
       .package = "freesurfer"
     )
+    local_mocked_bindings(fs_sitrep_safe = function() invisible(NULL))
 
     expect_message(result <- setup_sitrep("simple"))
 
@@ -17,9 +17,9 @@ describe("setup_sitrep", {
   it("accepts detail parameter", {
     local_mocked_bindings(
       have_fs = function() TRUE,
-      fs_sitrep = function() invisible(NULL),
       .package = "freesurfer"
     )
+    local_mocked_bindings(fs_sitrep_safe = function() invisible(NULL))
 
     expect_no_error(expect_message(setup_sitrep("simple")))
     expect_no_error(expect_message(setup_sitrep("full")))
@@ -157,7 +157,9 @@ describe("find_chrome_path", {
     )
     local_mocked_bindings(
       file.exists = function(path) {
-        if (any(grepl("Chrome|Chromium|chrome", path))) return(FALSE)
+        if (any(grepl("Chrome|Chromium|chrome", path))) {
+          return(FALSE)
+        }
         base::file.exists(path)
       },
       .package = "base"


### PR DESCRIPTION
## Summary
- Tests calling `ggseg3d::ggseg3d()` directly (without mocking) fail on Windows CI with: `ggseg.meshes is required for "pial". Install with: install.packages('ggseg.meshes')`
- Added `skip_if_not_installed("ggseg.meshes")` guards to all 5 affected test blocks across 4 files:
  - `test-integration.R` (2 tests)
  - `test-atlas-cortical.R` (1 test)
  - `test-atlas-subcortical.R` (1 test)
  - `test-atlas-tracts.R` (1 test)

## Test plan
- [ ] Verify R-CMD-check passes on all platforms (especially Windows)
- [ ] Confirm tests still run when ggseg.meshes is available


🤖 Generated with [Claude Code](https://claude.com/claude-code)