### PR TITLE
BF Removing trailing semi-colon from fs_cmd

### DIFF
--- a/R/utils-snapshot.R
+++ b/R/utils-snapshot.R
@@ -222,7 +222,8 @@ magick_version <- function() {
 
 #' @noRd
 run_cmd <- function(cmd, verbose = get_verbose(), no_ui = FALSE) {
-  # nolint: object_usage_linter
+                                        # nolint: object_usage_linter
+  print(cmd)
   if (no_ui) {
     if (Sys.info()["sysname"] == "Darwin") {
       fv_args <- sub("^freeview[[:space:]]*", "", cmd)
@@ -236,7 +237,7 @@ run_cmd <- function(cmd, verbose = get_verbose(), no_ui = FALSE) {
       cmd <- paste("fsxvfb", cmd)
     }
   }
-  full_cmd <- paste0(freesurfer::get_fs(), cmd)
+  full_cmd <- paste0(sub(";\\s*$", "", freesurfer::get_fs()), "; ", cmd)
   suppress <- verbose < 2
   exit_code <- system(
     paste("bash -c", shQuote(full_cmd)),

--- a/R/utils-snapshot.R
+++ b/R/utils-snapshot.R
@@ -237,7 +237,12 @@ run_cmd <- function(cmd, verbose = get_verbose(), no_ui = FALSE) {
       cmd <- paste("fsxvfb", cmd)
     }
   }
-  full_cmd <- paste0(sub(";\\s*$", "", freesurfer::get_fs()), "; ", cmd)
+  fs_init <- sub(";\\s*$", "", freesurfer::get_fs())
+  full_cmd <- if (nzchar(trimws(fs_init))) {
+    paste0(fs_init, "; ", cmd)
+  } else {
+    cmd
+  }
   suppress <- verbose < 2
   exit_code <- system(
     paste("bash -c", shQuote(full_cmd)),


### PR DESCRIPTION
Refactor command construction to trim whitespace and improve command execution.

## Description

The PR removes an unnecessary semi-colon from the fs_cmd function in util-snapshot.R that was causing an error when running freesurfer.

## Related Issues
https://github.com/ggsegverse/ggseg.extra/issues/82#issue-4548630468

Fixes #(issue number)
#82 
## Type of Change

- [X ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (describe):

## Checklist

- [ NA] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ NA] I have run `devtools::check()` with no errors
- [ NA] I have added tests for my changes (if applicable)
- [NA ] I have updated documentation (if applicable)
- [Y ] My code follows the tidyverse style guide
