### PR TITLE
Remove Trailing semi-colons

### DIFF
--- a/R/utils-snapshot.R
+++ b/R/utils-snapshot.R
@@ -222,7 +222,7 @@ magick_version <- function() {
 
 #' @noRd
 run_cmd <- function(cmd, verbose = get_verbose(), no_ui = FALSE) {
-# Clean trailing semicolon before execution
+  # Clean trailing semicolon before execution
   cmd_clean <- sub(";\\s*$", "", cmd)
   if (!nzchar(trimws(cmd_clean))) {
     cli::cli_abort("Command string is empty or contains only semicolons")

--- a/R/utils-snapshot.R
+++ b/R/utils-snapshot.R
@@ -222,6 +222,12 @@ magick_version <- function() {
 
 #' @noRd
 run_cmd <- function(cmd, verbose = get_verbose(), no_ui = FALSE) {
+# Clean trailing semicolon before execution
+  cmd_clean <- sub(";\\s*$", "", cmd)
+  if (!nzchar(trimws(cmd_clean))) {
+    cli::cli_abort("Command string is empty or contains only semicolons")
+  }
+  cmd <- cmd_clean
   # nolint: object_usage_linter
   if (no_ui) {
     if (Sys.info()["sysname"] == "Darwin") {

--- a/tests/testthat/test-utils-snapshot.R
+++ b/tests/testthat/test-utils-snapshot.R
@@ -455,8 +455,42 @@ describe("run_cmd", {
       "FreeSurfer command failed"
     )
   })
-})
 
+  it("removes trailing semicolon from command", {
+    skip_on_os("windows")
+    local_mocked_bindings(
+      get_fs = function() "",
+      .package = "freesurfer"
+    )
+
+    result <- run_cmd("echo test;", verbose = FALSE, no_ui = FALSE)
+    expect_equal(result, 0L)
+  })
+
+  it("handles command with trailing semicolon and whitespace", {
+    skip_on_os("windows")
+    local_mocked_bindings(
+      get_fs = function() "",
+      .package = "freesurfer"
+    )
+
+    result <- run_cmd("echo test; \t", verbose = FALSE, no_ui = FALSE)
+    expect_equal(result, 0L)
+  })
+
+  it("aborts when command becomes empty after cleanup", {
+    skip_on_os("windows")
+    local_mocked_bindings(
+      get_fs = function() "",
+      .package = "freesurfer"
+    )
+
+    expect_error(
+      run_cmd(";", verbose = FALSE, no_ui = FALSE),
+      "Command string is empty"
+    )
+  })
+})
 
 describe("get_contours", {
   it("returns NULL when max value < max_val", {


### PR DESCRIPTION
## Description

All calls to run_cmd are checked for trailing semi-colons.  These are removed, and an error is returned if the resulting command is empty.

Tests added for this behaviour.

## Related Issues
#82 

Fixes #(issue number)
#82 

## Type of Change

- [X ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (describe):

## Checklist

- [X ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ X] I have run `devtools::check()` with no errors
- [ X] I have added tests for my changes (if applicable)
- [ X] I have updated documentation (if applicable)
- [X ] My code follows the tidyverse style guide
