### PR TITLE
ci: add release-on-version caller stub

### DIFF
--- a/.github/workflows/release-on-version.yaml
+++ b/.github/workflows/release-on-version.yaml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches: [main, master]
+    paths: [DESCRIPTION]
+  workflow_dispatch: # manual trigger, e.g. to backfill a missed release
+
+name: release-on-version.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ggsegverse/.github/.github/workflows/release-on-version.yaml@main


### PR DESCRIPTION
## Summary
- Thin caller stub invoking the reusable `ggsegverse/.github/.github/workflows/release-on-version.yaml@main`.
- Tags + creates a GitHub release when DESCRIPTION Version is `x.y.z`; dev versions (`x.y.z.9000`) are skipped.

## Test plan
- [ ] Merge on green CI; validated end-to-end on ggseg3d (safe no-op at the tag guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)