### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.gp.outputs.status == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Node 20 action runtime is deprecated on GitHub Actions. Bumps GitHub's JS actions to their Node 24 majors. Composite actions (all r-lib/actions@v2, codecov@v5, quarto, r-hub) have no node runtime and are unaffected.

Version bumps: checkout v4/v3->v6, upload-artifact v4->v6, download-artifact v4->v7, setup-python v5->v6, github-script v7->v8, deploy-pages v4->v5, create-pull-request v7->v8, setup-chrome v1->v2, codecov v4->v5, JamesIves v4.4.1/v4.5.0->v4.8.0.