### PR TITLE
ci: adopt pkgdown reusable

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,4 +1,3 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 on:
   push:
     branches: [main, master]
@@ -8,50 +7,16 @@ on:
 
 name: pkgdown
 
-permissions: read-all
+permissions:
+  contents: write
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - name: Install Linux system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgdal-dev libproj-dev libgeos-dev libudunits2-dev
-          sudo apt-get install -y libmagick++-dev libglpk-dev
-          sudo apt-get install -y libharfbuzz-dev libfribidi-dev
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::pkgdown,
-            any::quarto,
-            github::drmowinckels/freesurfer@refactor,
-            local::.
-          needs: website
-
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
-        with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+    uses: ggsegverse/.github/.github/workflows/pkgdown.yaml@main
+    with:
+      install-spatial-deps: true
+      extra-packages: |
+        any::pkgdown
+        any::quarto
+        github::drmowinckels/freesurfer@refactor
+        local::.


### PR DESCRIPTION
Replace the copied pkgdown workflow with a caller stub for the shared reusable in `ggsegverse/.github`. Per-repo triggers and inputs (chromote / spatial deps / extra-packages) preserved. Deploy stays push/release-guarded. Validated on ggseg.formats (standard) and ggseg3d (chromote).