### PR TITLE
ci: adopt update-codemeta reusable

### DIFF
--- a/.github/workflows/update-codemeta.yaml
+++ b/.github/workflows/update-codemeta.yaml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - DESCRIPTION
+      - .github/workflows/update-codemeta.yaml
+  workflow_dispatch:
+
+name: update-codemeta
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-codemeta:
+    uses: ggsegverse/.github/.github/workflows/update-codemeta.yaml@main
+    secrets: inherit
+    with:
+      # ggseg.extra's package install pulls terra/GDAL + FreeSurfer (too large
+      # for GHA), so skip local::. — write_codemeta() reads DESCRIPTION directly.
+      extra-packages: any::codemetar


### PR DESCRIPTION
Adopt the shared `update-codemeta` reusable in `ggsegverse/.github` (PR #7). Regenerates `codemeta.json` from DESCRIPTION and merges via the least-privilege ggseg-bot app token (ruleset bypass, PR-merge only). Validated end-to-end on ggseg.formats (bot opened + signed-merged PR #28, zero reviews).