### PR TITLE
fix: reorient FreeSurfer .mgz volumes to RAS+ in read_volume()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # ggseg.extra 1.9.9.9005
 
+## Bug fixes
+
+- `read_volume()` now reorients FreeSurfer `.mgz` volumes to RAS+, matching
+  its long-standing behaviour for NIfTI inputs. Previously only `niftiImage`
+  objects were reoriented, so `.mgz` volumes (e.g. FreeSurfer's LIA-oriented
+  `aseg.mgz`) reached the RAS+-assuming projection code still in LIA order.
+  Subcortical
+  atlases built directly from a `.mgz` therefore came out left-right flipped in
+  axial views, top-bottom flipped in coronal, and 90-degrees rotated in
+  sagittal; atlases built from reoriented `.nii.gz` volumes (and tract atlases,
+  whose geometry is already in scanner RAS) were unaffected. Volumes whose
+  header carries no valid RAS information fall back to native voxel order.
+
 ## Subcortical atlas builder helpers
 
 New thin compositions of the existing `ggseg.formats` atlas ops and the

--- a/R/read_write.R
+++ b/R/read_write.R
@@ -683,6 +683,43 @@ fill_missing_colours <- function(result) {
 }
 
 
+#' Reorient a voxel array to RAS+ using its vox2ras affine
+#'
+#' Derives the axis permutation and per-axis flips that map a volume's voxel
+#' axes to Right-Anterior-Superior from the direction part of its vox2ras
+#' matrix, then applies them. This is the array-level equivalent of
+#' `RNifti::orientation<-`, used for FreeSurfer MGZ volumes (read as plain
+#' arrays, e.g. the LIA-oriented conformed volumes), which would otherwise
+#' reach the RAS+-assuming projection code unreoriented.
+#'
+#' @param vol 3D array in the file's native voxel order.
+#' @param vox2ras 4x4 voxel-to-scanner-RAS affine (only the 3x3 direction
+#'   block is used).
+#' @return `vol` reordered and flipped so dim1 increases toward Right,
+#'   dim2 toward Anterior, dim3 toward Superior.
+#' @keywords internal
+#' @noRd
+reorient_volume_to_ras <- function(vol, vox2ras) {
+  direction <- vox2ras[1:3, 1:3, drop = FALSE]
+  voxel_axis <- apply(abs(direction), 1L, which.max)
+  if (!setequal(voxel_axis, 1:3)) {
+    cli::cli_abort(
+      "Cannot derive a RAS axis mapping from the volume's vox2ras affine."
+    )
+  }
+
+  vol <- aperm(vol, voxel_axis)
+  for (world_axis in 1:3) {
+    if (direction[world_axis, voxel_axis[world_axis]] < 0) {
+      index <- lapply(dim(vol), seq_len)
+      index[[world_axis]] <- rev(index[[world_axis]])
+      vol <- do.call(`[`, c(list(vol), index, list(drop = FALSE)))
+    }
+  }
+  vol
+}
+
+
 #' Read neuroimaging volume file
 #'
 #' Reads volume data from common neuroimaging formats including
@@ -712,7 +749,19 @@ read_volume <- function(file, reorient = TRUE) {
 
   vol <- switch(
     ext,
-    "mgz" = freesurferformats::read.fs.mgh(file),
+    "mgz" = {
+      mgh <- freesurferformats::read.fs.mgh(file, with_header = TRUE)
+      data <- drop(mgh$data)
+      vox2ras <- tryCatch(
+        freesurferformats::mghheader.vox2ras(mgh$header),
+        error = function(e) NULL
+      )
+      if (reorient && length(dim(data)) == 3L && !is.null(vox2ras)) {
+        reorient_volume_to_ras(data, vox2ras)
+      } else {
+        data
+      }
+    },
     "nii" = {
       rlang::check_installed("RNifti", reason = "to read NIfTI files")
       RNifti::readNifti(file)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -34,6 +34,7 @@ HCP
 ImageMagick
 Infratentorial
 LCBC
+LIA
 LTA
 LUT
 Lifebrain

--- a/tests/testthat/test-read_write.R
+++ b/tests/testthat/test-read_write.R
@@ -56,6 +56,84 @@ describe("read_volume with reorient FALSE", {
 })
 
 
+describe("reorient_volume_to_ras", {
+  # LIA vox2ras: axis1 -> Left (-R), axis2 -> Inferior (-S), axis3 -> Anterior
+  lia <- rbind(c(-1, 0, 0), c(0, 0, 1), c(0, -1, 0))
+
+  it("reorients an LIA volume to RAS+", {
+    vol <- array(0L, dim = c(2, 2, 2))
+    vol[1, 1, 1] <- 1L
+
+    out <- reorient_volume_to_ras(vol, lia)
+
+    expect_identical(dim(out), c(2L, 2L, 2L))
+    # [1,1,1] in LIA = most Left, Superior, Posterior -> in RAS that voxel is at
+    # max-R (dim1=2), min-A (dim2=1), max-S (dim3=2)
+    expect_equal(
+      which(out == 1L, arr.ind = TRUE)[1, ],
+      c(2L, 1L, 2L),
+      ignore_attr = TRUE
+    )
+  })
+
+  it("leaves an already-RAS volume unchanged", {
+    vol <- array(seq_len(8), dim = c(2, 2, 2))
+    expect_equal(reorient_volume_to_ras(vol, diag(4)), vol)
+  })
+
+  it("accepts a bare 3x3 direction matrix", {
+    vol <- array(seq_len(8), dim = c(2, 2, 2))
+    expect_equal(reorient_volume_to_ras(vol, diag(3)), vol)
+  })
+
+  it("errors when the affine has no clear axis mapping", {
+    vol <- array(0L, dim = c(2, 2, 2))
+    degenerate <- rbind(c(1, 1, 0), c(1, 1, 0), c(0, 0, 1))
+    expect_error(
+      reorient_volume_to_ras(vol, degenerate),
+      "RAS axis mapping"
+    )
+  })
+})
+
+
+describe("read_volume MGZ reorientation", {
+  lia <- rbind(c(-1, 0, 0, 2), c(0, 0, 1, -2), c(0, -1, 0, 2), c(0, 0, 0, 1))
+
+  make_lia_mgz <- function() {
+    tmp <- withr::local_tempfile(
+      fileext = ".mgz",
+      .local_envir = parent.frame()
+    )
+    vol <- array(0L, dim = c(4, 4, 4))
+    vol[1, 1, 1] <- 7L
+    freesurferformats::write.fs.mgh(tmp, vol, vox2ras_matrix = lia)
+    tmp
+  }
+
+  it("reorients a native-LIA MGZ to RAS+ by default", {
+    out <- read_volume(make_lia_mgz())
+
+    expect_identical(dim(out), c(4L, 4L, 4L))
+    expect_equal(
+      which(out == 7L, arr.ind = TRUE)[1, ],
+      c(4L, 1L, 4L),
+      ignore_attr = TRUE
+    )
+  })
+
+  it("preserves native voxel order when reorient is FALSE", {
+    out <- read_volume(make_lia_mgz(), reorient = FALSE)
+
+    expect_equal(
+      which(out == 7L, arr.ind = TRUE)[1, ],
+      c(1L, 1L, 1L),
+      ignore_attr = TRUE
+    )
+  })
+})
+
+
 describe("read_ctab", {
   it("reads color table from file", {
     lut_file <- test_lut_file()


### PR DESCRIPTION
## Summary

`read_volume()` only reoriented NIfTI (`niftiImage`) inputs to RAS+, leaving FreeSurfer `.mgz` volumes in their native orientation. FreeSurfer conformed volumes are **LIA**, so atlases built directly from a `.mgz` (e.g. `aseg` from `aseg.mgz`) reached the RAS+-assuming projection code mis-oriented:

- axial views left–right flipped
- coronal views top–bottom flipped
- sagittal views rotated 90°

Atlases fed reoriented `.nii.gz` volumes, and tract atlases (geometry already in scanner RAS), were unaffected — which is why only the `aseg` atlas showed the problem.

Adds a pure `reorient_volume_to_ras()` helper that derives the axis permutation and per-axis flips from the mgh `vox2ras` affine, and applies it in the `.mgz` read path. Volumes whose header carries no valid RAS information fall back to native voxel order.

## Test plan

- New unit tests for `reorient_volume_to_ras()` (LIA→RAS, identity, bare 3×3 affine, degenerate-affine error) and an end-to-end `read_volume()` test that writes a synthetic LIA `.mgz` and confirms reorientation — no FreeSurfer required.
- Verified by rebuilding `aseg` from `aseg.mgz`: every reference structure (putamen, thalamus, L/R) returns to the shipped left/right and superior/inferior position across all views.
- `air format`, `lintr`, and `spelling` clean; full test suite green (**1792 passed, 0 failed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)