### PR TITLE
fix: resolve 2 blocking + 10 required issues from code review

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg.extra
 Title: Create Brain Atlases for the 'ggsegverse' Plotting Ecosystem
-Version: 1.9.9.9006
+Version: 1.9.9.9007
 Authors@R: c(
     person(
         given = "Athanasia Mo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ggseg.extra 1.9.9.9006
+# ggseg.extra 1.9.9.9007
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,8 @@
 - `read_tractography()` reads `.trk` files whose header track count is `0`. The
   TrackVis format uses `0` to mean "count not recorded, read to end of file";
   the reader previously trusted the count and returned no streamlines, yielding
-  an empty atlas. It now reads to EOF and treats a positive count as an upper
-  bound.
+  an empty atlas. It now reads to the end of the file and treats a positive
+  count as an upper bound.
 - `create_cortical_from_neuromaps()` / `read_neuromaps_volume()` no longer abort
   with `'breaks' are not unique` when a continuous map has tied values (common
   for thresholded maps or maps with many zeros). Duplicate quantile breaks are
@@ -20,7 +20,7 @@
 - Tract atlases built from in-memory streamline matrices (e.g.
   `create_tract_from_tractography(input_tracts = list(cst = matrix(...)))`) now
   detect voxel- versus RAS-space correctly. Detection previously flattened the
-  matrices and always assumed RAS, mislocating voxel-space tracts.
+  matrices and always assumed RAS, misplacing voxel-space tracts.
 - `create_tract_from_tractography()` now reads the voxel-to-world affine from
   FreeSurfer `.mgz` headers correctly, and warns instead of silently falling
   back to an approximate origin-centering heuristic when a template's affine
@@ -35,7 +35,7 @@
   any contour instead of a cryptic `dplyr` failure.
 - Verbosity and boolean options parse spelled-out strings consistently:
   `GGSEG_EXTRA_VERBOSE=false` now silences output, and string values such as
-  `"yes"` or `"1"` are honoured across the explicit, option, and
+  `"yes"` or `"1"` are honored across the explicit, option, and
   environment-variable channels.
 
 # ggseg.extra 1.9.9.9005

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,43 @@
+# ggseg.extra 1.9.9.9006
+
+## Bug fixes
+
+- `create_cerebellar_from_volume()` no longer errors on float-typed
+  parcellation volumes. Sampling labels at the SUIT surface forced an integer
+  `vapply()` template, so a double array — e.g. the SUIT volume written by
+  `transform_mni_to_suit()` — aborted the build. The volume is now coerced to
+  integer before sampling.
+- `read_tractography()` reads `.trk` files whose header track count is `0`. The
+  TrackVis format uses `0` to mean "count not recorded, read to end of file";
+  the reader previously trusted the count and returned no streamlines, yielding
+  an empty atlas. It now reads to EOF and treats a positive count as an upper
+  bound.
+- `create_cortical_from_neuromaps()` / `read_neuromaps_volume()` no longer abort
+  with `'breaks' are not unique` when a continuous map has tied values (common
+  for thresholded maps or maps with many zeros). Duplicate quantile breaks are
+  collapsed and the bin count is reduced with a warning; an all-medial-wall
+  hemisphere now errors with a clear message.
+- Tract atlases built from in-memory streamline matrices (e.g.
+  `create_tract_from_tractography(input_tracts = list(cst = matrix(...)))`) now
+  detect voxel- versus RAS-space correctly. Detection previously flattened the
+  matrices and always assumed RAS, mislocating voxel-space tracts.
+- `create_tract_from_tractography()` now reads the voxel-to-world affine from
+  FreeSurfer `.mgz` headers correctly, and warns instead of silently falling
+  back to an approximate origin-centering heuristic when a template's affine
+  cannot be read.
+- `create_subcortical_from_volume()` derives a default `atlas_name` of `aseg`
+  (not `aseg.nii`) from a `.nii.gz` input.
+- `mri_info` is now called with a shell-quoted volume path, so cerebellar
+  deep-nuclei meshing works for volume paths that contain spaces.
+- Contour extraction (subcortical and tract 2D geometry) no longer crashes on
+  empty or all-`NA` region rasters, keeps the valid contours when only some
+  region geometries are empty, and reports a clear error when no region yields
+  any contour instead of a cryptic `dplyr` failure.
+- Verbosity and boolean options parse spelled-out strings consistently:
+  `GGSEG_EXTRA_VERBOSE=false` now silences output, and string values such as
+  `"yes"` or `"1"` are honoured across the explicit, option, and
+  environment-variable channels.
+
 # ggseg.extra 1.9.9.9005
 
 ## Bug fixes

--- a/R/atlas_cerebellar.R
+++ b/R/atlas_cerebellar.R
@@ -1148,7 +1148,7 @@ get_tkras_to_world <- function(volume_path) {
 mri_info_matrix <- function(flag, volume_path) {
   lines <- system2(
     "mri_info",
-    c(flag, volume_path),
+    c(flag, shQuote(volume_path)),
     stdout = TRUE,
     stderr = TRUE
   )
@@ -1676,6 +1676,12 @@ sample_volume_at_surface <- function(vol, volume_path, suit_3d_surface) {
 
   nii <- RNifti::readNifti(volume_path)
   vox_coords <- RNifti::worldToVoxel(verts_3d, nii)
+
+  # Label volumes are integer parcellations, but read_volume() returns a double
+  # array for float-typed files (e.g. a SUIT volume from transform_mni_to_suit).
+  # Force integer storage so the neighbour lookup's vapply(integer(1)) template
+  # holds instead of erroring on a double element.
+  storage.mode(vol) <- "integer"
 
   dims <- dim(vol)
   n_verts <- nrow(vox_coords)

--- a/R/atlas_geometry.R
+++ b/R/atlas_geometry.R
@@ -164,7 +164,7 @@ probe_raster_max <- function(regions) {
   for (f in regions[seq_len(min(10, length(regions)))]) {
     r <- suppressWarnings(terra::rast(f))
     m <- terra::global(r, fun = "max", na.rm = TRUE)[1, 1]
-    if (m > max_val) {
+    if (is.finite(m) && m > max_val) {
       max_val <- m
     }
     if (max_val > 0) break
@@ -213,6 +213,13 @@ map_region_contours <- function(regions, max_val, vertex_size_limits, step) {
 combine_region_contours <- function(contourobjs) {
   kp <- !vapply(contourobjs, is.null, logical(1))
   contourobjs2 <- contourobjs[kp]
+
+  if (length(contourobjs2) == 0) {
+    cli::cli_abort(c(
+      "No contours were extracted from any region",
+      "i" = "Every region raster was empty or below the contour threshold"
+    ))
+  }
 
   contours <- bind_rows(contourobjs2, .id = "filenm")
   contours <- group_by(contours, filenm)

--- a/R/atlas_subcortical.R
+++ b/R/atlas_subcortical.R
@@ -412,7 +412,7 @@ validate_subcort_config <- function(
   config$output_dir <- normalizePath(config$output_dir, mustWork = FALSE)
 
   if (is.null(atlas_name)) {
-    atlas_name <- file_path_sans_ext(basename(input_volume))
+    atlas_name <- default_atlas_name_from_volume(input_volume)
   }
 
   config$input_volume <- input_volume
@@ -439,6 +439,17 @@ validate_decimate <- function(decimate) {
     ))
   }
   invisible(NULL)
+}
+
+
+#' Derive a default atlas name from a volume file path
+#'
+#' Strips the directory and the full extension, including the `.gz`/`.bz2`
+#' compression suffix, so `aseg.nii.gz` and `aseg.mgz` both become `aseg`
+#' rather than leaving a stray `.nii` on gzipped inputs.
+#' @noRd
+default_atlas_name_from_volume <- function(input_volume) {
+  file_path_sans_ext(basename(input_volume), compression = TRUE)
 }
 
 

--- a/R/read_write.R
+++ b/R/read_write.R
@@ -1076,6 +1076,13 @@ parse_continuous_values <- function(values, hemi, hemi_short, n_bins) {
   medial_wall <- !is.finite(values)
   valid <- values[!medial_wall]
 
+  if (length(valid) == 0) {
+    cli::cli_abort(c(
+      "No finite values to bin for the {hemi} hemisphere",
+      "i" = "Every projected vertex was medial wall or non-finite"
+    ))
+  }
+
   if (is.null(n_bins)) {
     n_bins <- as.integer(grDevices::nclass.Sturges(valid))
     n_bins <- max(5L, min(n_bins, 20L))
@@ -1083,6 +1090,19 @@ parse_continuous_values <- function(values, hemi, hemi_short, n_bins) {
 
   breaks <- stats::quantile(valid, probs = seq(0, 1, length.out = n_bins + 1))
   breaks[1] <- breaks[1] - 1
+
+  # Tied values (thresholded maps, many zeros, or n_bins larger than the number
+  # of distinct values) collapse adjacent quantiles; cut() aborts on duplicate
+  # breaks, so drop them and shrink the bin count to match.
+  breaks <- unique(breaks)
+  if (length(breaks) - 1L < n_bins) {
+    cli::cli_warn(
+      "Using {length(breaks) - 1L} bin{?s} instead of {n_bins}: the data has \\
+       fewer distinct values than requested bins."
+    )
+    n_bins <- length(breaks) - 1L
+  }
+
   bin_ids <- cut(values, breaks = breaks, labels = FALSE)
   bin_ids[medial_wall] <- NA_integer_
 

--- a/R/tract_geometry.R
+++ b/R/tract_geometry.R
@@ -410,28 +410,49 @@ load_vox2ras_matrix <- function(template_file, coords_are_voxels) {
     ext <- tools::file_ext(sub("\\.gz$", "", template_file))
   }
 
+  vox2ras <- read_vox2ras(template_file, ext)
+
+  if (is.null(vox2ras)) {
+    cli::cli_warn(c(
+      "Could not read a voxel-to-world affine from {.path {template_file}}.",
+      "!" = "Falling back to an approximate origin-centering heuristic; \\
+             RAS streamlines may be placed at the wrong voxels.",
+      "i" = "Install the matching reader package, or pass a volume whose \\
+             header carries a valid affine."
+    ))
+  }
+
+  vox2ras
+}
+
+#' Read a volume's voxel-to-world affine, or `NULL` if it can't be read
+#'
+#' Returns `NULL` for an unsupported extension, a missing reader package, or a
+#' header read error; the caller decides how to report the fallback.
+#' @noRd
+read_vox2ras <- function(template_file, ext) {
   if (ext == "mgz") {
     if (!requireNamespace("freesurferformats", quietly = TRUE)) {
       return(NULL)
     }
-    tryCatch(
-      freesurferformats::read.fs.mgh(template_file, with_header = TRUE)$vox2ras,
+    return(tryCatch(
+      {
+        mgh <- freesurferformats::read.fs.mgh(template_file, with_header = TRUE)
+        freesurferformats::mghheader.vox2ras(mgh$header)
+      },
       error = function(e) NULL
-    )
-  } else if (ext == "nii") {
+    ))
+  }
+  if (ext == "nii") {
     if (!requireNamespace("RNifti", quietly = TRUE)) {
       return(NULL)
     }
-    tryCatch(
-      {
-        hdr <- RNifti::niftiHeader(template_file)
-        RNifti::xform(hdr)
-      },
+    return(tryCatch(
+      RNifti::xform(RNifti::niftiHeader(template_file)),
       error = function(e) NULL
-    )
-  } else {
-    NULL
+    ))
   }
+  NULL
 }
 
 
@@ -644,7 +665,13 @@ snapshot_cortex_views <- function(
 #' Auto-detect tract coordinate space and report it when verbose
 #' @noRd
 detect_tract_coord_space <- function(streamlines, verbose) {
-  all_streamlines <- unlist(streamlines, recursive = FALSE)
+  # Flatten to a flat list of matrices. Direct in-memory input is a list of
+  # matrices (one per tract); unlisting those with recursive = FALSE would
+  # collapse each matrix into a numeric vector and lose the coordinate columns.
+  all_streamlines <- unlist(
+    lapply(streamlines, function(x) if (is.matrix(x)) list(x) else x),
+    recursive = FALSE
+  )
   coords_are_voxels <- detect_coords_are_voxels(all_streamlines)
   if (verbose) {
     space <- if (coords_are_voxels) "voxel" else "RAS" # nolint: object_usage_linter

--- a/R/tract_io.R
+++ b/R/tract_io.R
@@ -63,32 +63,40 @@ read_trk <- function(file) {
   # The header's stored track count is unreliable: the TrackVis spec allows 0
   # to mean "count not recorded, read to EOF", and some writers leave it so.
   # Read streamlines until EOF, using a positive n_count only as an upper bound.
-  max_tracks <- if (is.na(n_count) || n_count <= 0L) Inf else n_count
+  max_tracks <- if (isTRUE(n_count > 0L)) n_count else Inf
 
   streamlines <- list()
-  i <- 0L
-  while (i < max_tracks) {
-    n_pts <- readBin(con, "integer", 1, size = 4)
-    if (length(n_pts) == 0L || is.na(n_pts) || n_pts <= 0) {
+  while (length(streamlines) < max_tracks) {
+    points <- read_trk_streamline(con, n_scalars, n_properties)
+    if (is.null(points)) {
       break
     }
-    i <- i + 1L
-
-    points <- matrix(
-      readBin(con, "double", n_pts * (3 + n_scalars), size = 4),
-      ncol = 3 + n_scalars,
-      byrow = TRUE
-    )
-
-    streamlines[[i]] <- points[, 1:3, drop = FALSE]
-    colnames(streamlines[[i]]) <- c("x", "y", "z")
-
-    if (n_properties > 0) {
-      readBin(con, "double", n_properties, size = 4)
-    }
+    streamlines[[length(streamlines) + 1L]] <- points
   }
 
   streamlines
+}
+
+#' Read one TRK streamline's x/y/z coordinates, or `NULL` at end of file
+#' @noRd
+read_trk_streamline <- function(con, n_scalars, n_properties) {
+  n_pts <- readBin(con, "integer", 1, size = 4)
+  if (length(n_pts) == 0L || is.na(n_pts) || n_pts <= 0) {
+    return(NULL)
+  }
+
+  points <- matrix(
+    readBin(con, "double", n_pts * (3 + n_scalars), size = 4),
+    ncol = 3 + n_scalars,
+    byrow = TRUE
+  )[, 1:3, drop = FALSE]
+  colnames(points) <- c("x", "y", "z")
+
+  if (n_properties > 0) {
+    readBin(con, "double", n_properties, size = 4)
+  }
+
+  points
 }
 
 

--- a/R/tract_io.R
+++ b/R/tract_io.R
@@ -60,13 +60,19 @@ read_trk <- function(file) {
 
   seek(con, 1000)
 
-  streamlines <- list()
+  # The header's stored track count is unreliable: the TrackVis spec allows 0
+  # to mean "count not recorded, read to EOF", and some writers leave it so.
+  # Read streamlines until EOF, using a positive n_count only as an upper bound.
+  max_tracks <- if (is.na(n_count) || n_count <= 0L) Inf else n_count
 
-  for (i in seq_len(n_count)) {
+  streamlines <- list()
+  i <- 0L
+  while (i < max_tracks) {
     n_pts <- readBin(con, "integer", 1, size = 4)
-    if (is.na(n_pts) || n_pts <= 0) {
+    if (length(n_pts) == 0L || is.na(n_pts) || n_pts <= 0) {
       break
     }
+    i <- i + 1L
 
     points <- matrix(
       readBin(con, "double", n_pts * (3 + n_scalars), size = 4),

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,23 +32,6 @@ as_verbosity <- function(x) {
   min(x, 2L)
 }
 
-#' Match a spelled-out boolean string, returning `NA` for anything else
-#'
-#' Numeric strings like `"0"`/`"1"` deliberately return `NA` so callers that
-#' also accept numbers (e.g. [as_verbosity()]) route them through their own
-#' numeric handling instead.
-#' @noRd
-match_bool_word <- function(x) {
-  word <- tolower(trimws(as.character(x)))
-  if (word %in% c("true", "yes", "on")) {
-    return(TRUE)
-  }
-  if (word %in% c("false", "no", "off")) {
-    return(FALSE)
-  }
-  NA
-}
-
 #' Get verbose setting
 #'
 #' Returns the verbosity level from option, environment variable, or default.
@@ -451,6 +434,23 @@ get_bool_option <- function(explicit, option_name, env_name, default) {
   }
 
   default
+}
+
+#' Match a spelled-out boolean string, returning `NA` for anything else
+#'
+#' Numeric strings like `"0"`/`"1"` deliberately return `NA` so callers that
+#' also accept numbers (e.g. [as_verbosity()]) route them through their own
+#' numeric handling instead.
+#' @noRd
+match_bool_word <- function(x) {
+  word <- tolower(trimws(as.character(x)))
+  if (word %in% c("true", "yes", "on")) {
+    return(TRUE)
+  }
+  if (word %in% c("false", "no", "off")) {
+    return(FALSE)
+  }
+  NA
 }
 
 #' Coerce a value to a single logical, accepting common string spellings

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,11 +19,34 @@ as_verbosity <- function(x) {
   if (is.logical(x) && !is.na(x)) {
     return(as.integer(x))
   }
+  if (is.character(x)) {
+    word_bool <- match_bool_word(x)
+    if (!is.na(word_bool)) {
+      return(as.integer(word_bool))
+    }
+  }
   x <- suppressWarnings(as.integer(x))
   if (is.na(x) || x < 0L) {
     return(1L)
   }
   min(x, 2L)
+}
+
+#' Match a spelled-out boolean string, returning `NA` for anything else
+#'
+#' Numeric strings like `"0"`/`"1"` deliberately return `NA` so callers that
+#' also accept numbers (e.g. [as_verbosity()]) route them through their own
+#' numeric handling instead.
+#' @noRd
+match_bool_word <- function(x) {
+  word <- tolower(trimws(as.character(x)))
+  if (word %in% c("true", "yes", "on")) {
+    return(TRUE)
+  }
+  if (word %in% c("false", "no", "off")) {
+    return(FALSE)
+  }
+  NA
 }
 
 #' Get verbose setting
@@ -414,20 +437,34 @@ warn_deprecated_sf_smoothing <- function(
 #' @noRd
 get_bool_option <- function(explicit, option_name, env_name, default) {
   if (!is.null(explicit)) {
-    return(as.logical(explicit))
+    return(coerce_bool(explicit))
   }
 
   opt <- getOption(option_name)
   if (!is.null(opt)) {
-    return(as.logical(opt))
+    return(coerce_bool(opt))
   }
 
   env <- Sys.getenv(env_name, unset = NA)
   if (!is.na(env)) {
-    return(tolower(env) %in% c("true", "1", "yes"))
+    return(coerce_bool(env))
   }
 
   default
+}
+
+#' Coerce a value to a single logical, accepting common string spellings
+#'
+#' Applied uniformly to the explicit, option, and environment-variable
+#' channels so `"yes"`, `"1"`, and `TRUE` mean the same thing however they
+#' are supplied. Unrecognised strings are `FALSE` rather than `NA`, so a
+#' downstream `if ()` never errors on a stray option value.
+#' @noRd
+coerce_bool <- function(x) {
+  if (is.logical(x)) {
+    return(isTRUE(x))
+  }
+  tolower(trimws(as.character(x))) %in% c("true", "1", "yes", "on")
 }
 
 #' Helper to get numeric option with fallback

--- a/R/utils_snapshot.R
+++ b/R/utils_snapshot.R
@@ -194,7 +194,7 @@ get_contours <- function(
   rlang::check_installed("terra", reason = "for contour extraction")
   mx <- terra::global(raster_object, fun = "max", na.rm = TRUE)[1, 1]
 
-  if (mx < max_val) {
+  if (is.na(mx) || mx < max_val) {
     return(NULL)
   }
 
@@ -205,7 +205,9 @@ get_contours <- function(
 
   coords <- st_as_sf(contours_raw)
 
-  if (all(nrow(coords) > 0 & !st_is_empty(coords))) {
+  keep <- !st_is_empty(coords)
+  if (nrow(coords) > 0 && any(keep)) {
+    coords <- coords[keep, ]
     coords <- to_coords(coords, 1)
     coords <- coords2sf(coords, vertex_size_limits)
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -76,6 +76,7 @@ XQuartz
 Xcode
 Yeo
 abagen
+affine
 annot
 aparc
 argmax

--- a/tests/testthat/test-atlas_cerebellar.R
+++ b/tests/testthat/test-atlas_cerebellar.R
@@ -863,6 +863,24 @@ describe("sample_volume_at_surface", {
     expect_length(result, 28935)
     expect_type(result, "integer")
   })
+
+  it("handles a double-typed (float) label volume without erroring", {
+    skip_if_not_installed("RNifti")
+    skip_if_not_installed("gifti") # nolint: object_usage_linter.
+
+    vol <- array(0, dim = c(5, 5, 5))
+    vol[2, 2, 2] <- 1
+    vol[4, 4, 4] <- 2
+    expect_identical(typeof(vol), "double")
+
+    vol_file <- withr::local_tempfile(fileext = ".nii.gz")
+    RNifti::writeNifti(RNifti::asNifti(vol), vol_file)
+
+    result <- sample_volume_at_surface(vol, vol_file, suit_3d_path())
+
+    expect_type(result, "integer")
+    expect_gt(length(result), 0)
+  })
 })
 
 
@@ -1990,6 +2008,27 @@ describe("get_tkras_to_world", {
 })
 
 describe("mri_info_matrix", {
+  it("shell-quotes the volume path so spaces don't split arguments", {
+    .cap$captured_args <- NULL
+    local_mocked_bindings(
+      system2 = function(command, args, ...) {
+        .cap$captured_args <- args
+        structure(
+          c(" 1 0 0 0", " 0 1 0 0", " 0 0 1 0", " 0 0 0 1"),
+          status = 0L
+        )
+      },
+      .package = "base"
+    )
+
+    mri_info_matrix("--vox2ras", "/data/my atlas/vol.nii.gz")
+
+    expect_identical(
+      .cap$captured_args,
+      c("--vox2ras", shQuote("/data/my atlas/vol.nii.gz"))
+    )
+  })
+
   it("ignores informational lines mri_info prints ahead of the matrix", {
     local_mocked_bindings(
       system2 = function(...) {

--- a/tests/testthat/test-atlas_cerebellar.R
+++ b/tests/testthat/test-atlas_cerebellar.R
@@ -871,7 +871,7 @@ describe("sample_volume_at_surface", {
     vol <- array(0, dim = c(5, 5, 5))
     vol[2, 2, 2] <- 1
     vol[4, 4, 4] <- 2
-    expect_identical(typeof(vol), "double")
+    expect_type(vol, "double")
 
     vol_file <- withr::local_tempfile(fileext = ".nii.gz")
     RNifti::writeNifti(RNifti::asNifti(vol), vol_file)

--- a/tests/testthat/test-atlas_geometry.R
+++ b/tests/testthat/test-atlas_geometry.R
@@ -487,6 +487,39 @@ describe("filter_valid_geometries", {
 })
 
 
+describe("combine_region_contours", {
+  it("aborts clearly when no region produced contours", {
+    expect_error(
+      combine_region_contours(list(a = NULL, b = NULL)),
+      "No contours were extracted"
+    )
+  })
+})
+
+
+describe("probe_raster_max", {
+  it("skips all-NA rasters instead of erroring", {
+    skip_if_not_installed("terra")
+    blank <- withr::local_tempfile(fileext = ".tif")
+    terra::writeRaster(
+      terra::rast(nrows = 4, ncols = 4, vals = NA_real_),
+      blank
+    )
+    expect_identical(probe_raster_max(blank), 1)
+  })
+
+  it("returns the maximum across region rasters", {
+    skip_if_not_installed("terra")
+    f <- withr::local_tempfile(fileext = ".tif")
+    terra::writeRaster(
+      terra::rast(nrows = 4, ncols = 4, vals = c(rep(0, 15), 200)),
+      f
+    )
+    expect_identical(probe_raster_max(f), 200)
+  })
+})
+
+
 describe("smooth_contours", {
   it("smooths contour geometry", {
     outdir <- withr::local_tempdir("smooth_test_")

--- a/tests/testthat/test-atlas_subcortical.R
+++ b/tests/testthat/test-atlas_subcortical.R
@@ -1,5 +1,22 @@
 .cap <- new.env()
 
+describe("default_atlas_name_from_volume", {
+  it("strips the full .nii.gz compression suffix", {
+    expect_identical(
+      default_atlas_name_from_volume("path/to/aseg.nii.gz"),
+      "aseg"
+    )
+  })
+
+  it("strips single extensions too", {
+    expect_identical(default_atlas_name_from_volume("aseg.mgz"), "aseg")
+    expect_identical(
+      default_atlas_name_from_volume("dir/thalamus.nii"),
+      "thalamus"
+    )
+  })
+})
+
 describe("create_subcortical_from_volume decimate validation", {
   it("errors for values outside (0, 1)", {
     local_mocked_bindings(check_fs = function(...) TRUE)

--- a/tests/testthat/test-read_write.R
+++ b/tests/testthat/test-read_write.R
@@ -732,6 +732,26 @@ describe("parse_continuous_values", {
     expect_lte(length(bin_regions), 10)
     expect_gte(length(bin_regions), 1)
   })
+
+  it("handles tied values without a 'breaks are not unique' error", {
+    values <- c(rep(NaN, 10000), rep(0, 200), rep(1, 42))
+    expect_warning(
+      result <- parse_continuous_values(values, "left", "lh", n_bins = 10),
+      "fewer distinct values"
+    )
+    bin_regions <- Filter(
+      function(x) grepl("^bin_", x$region[1]),
+      result
+    )
+    expect_gte(length(bin_regions), 1)
+  })
+
+  it("aborts clearly when no finite values remain", {
+    expect_error(
+      parse_continuous_values(rep(NaN, 100), "left", "lh", n_bins = 10),
+      "No finite values"
+    )
+  })
 })
 
 

--- a/tests/testthat/test-tract_geometry.R
+++ b/tests/testthat/test-tract_geometry.R
@@ -476,6 +476,31 @@ describe("detect_coords_are_voxels", {
 })
 
 
+describe("detect_tract_coord_space", {
+  it("detects voxel space from a list of bare matrices (in-memory input)", {
+    voxel_tracts <- list(
+      cst = matrix(c(10, 20, 30, 11, 21, 31), ncol = 3, byrow = TRUE),
+      af = matrix(c(5, 6, 7, 8, 9, 10), ncol = 3, byrow = TRUE)
+    )
+    expect_true(detect_tract_coord_space(voxel_tracts, verbose = FALSE))
+  })
+
+  it("detects RAS space from a list of bare matrices", {
+    ras_tracts <- list(
+      cst = matrix(c(-40, 10, 5, -38, 12, 6), ncol = 3, byrow = TRUE)
+    )
+    expect_false(detect_tract_coord_space(ras_tracts, verbose = FALSE))
+  })
+
+  it("handles file-style nested lists of matrices", {
+    nested <- list(
+      cst = list(matrix(c(10, 20, 30, 11, 21, 31), ncol = 3, byrow = TRUE))
+    )
+    expect_true(detect_tract_coord_space(nested, verbose = FALSE))
+  })
+})
+
+
 describe("extract_centerline medoid", {
   it("selects the most representative streamline", {
     streamlines <- list(
@@ -501,8 +526,11 @@ describe("load_vox2ras_matrix", {
     expect_null(result)
   })
 
-  it("returns NULL for unsupported file extension", {
-    result <- load_vox2ras_matrix("file.txt", FALSE)
+  it("warns and returns NULL for unsupported file extension", {
+    expect_warning(
+      result <- load_vox2ras_matrix("file.txt", FALSE),
+      "approximate origin-centering"
+    )
     expect_null(result)
   })
 })
@@ -609,12 +637,16 @@ describe("compute_streamline_density", {
 
 
 describe("load_vox2ras_matrix", {
-  it("loads vox2ras from mgz file", {
-    result <- load_vox2ras_matrix(
-      test_mgz_file(),
-      coords_are_voxels = FALSE
+  it("warns and falls back when the mgz header lacks RAS info", {
+    skip_if_not_installed("freesurferformats")
+    expect_warning(
+      result <- load_vox2ras_matrix(
+        test_mgz_file(),
+        coords_are_voxels = FALSE
+      ),
+      "approximate origin-centering"
     )
-    expect_true(is.matrix(result) || is.null(result))
+    expect_null(result)
   })
 
   it("handles .nii.gz extension by parsing gz correctly", {
@@ -653,7 +685,10 @@ describe("load_vox2ras_matrix", {
       .package = "base"
     )
 
-    result <- load_vox2ras_matrix("file.mgz", FALSE)
+    expect_warning(
+      result <- load_vox2ras_matrix("file.mgz", FALSE),
+      "approximate origin-centering"
+    )
     expect_null(result)
   })
 
@@ -669,7 +704,10 @@ describe("load_vox2ras_matrix", {
       .package = "base"
     )
 
-    result <- load_vox2ras_matrix("file.nii", FALSE)
+    expect_warning(
+      result <- load_vox2ras_matrix("file.nii", FALSE),
+      "approximate origin-centering"
+    )
     expect_null(result)
   })
 })

--- a/tests/testthat/test-tract_io.R
+++ b/tests/testthat/test-tract_io.R
@@ -91,6 +91,28 @@ describe("read_trk", {
     expect_identical(nrow(result[[2]]), 2L)
   })
 
+  it("reads to EOF when the header track count is 0 (spec-valid)", {
+    tmp <- withr::local_tempfile(fileext = ".trk")
+    con <- file(tmp, "wb")
+    header <- raw(1000)
+    header[1:6] <- c(charToRaw("TRACK"), as.raw(0))
+    header[37:38] <- writeBin(0L, raw(), size = 2)
+    header[239:240] <- writeBin(0L, raw(), size = 2)
+    header[989:992] <- writeBin(0L, raw(), size = 4)
+    writeBin(header, con)
+    writeBin(2L, con, size = 4)
+    writeBin(as.numeric(c(1, 2, 3, 4, 5, 6)), con, size = 4)
+    writeBin(2L, con, size = 4)
+    writeBin(as.numeric(c(7, 8, 9, 10, 11, 12)), con, size = 4)
+    close(con)
+
+    result <- read_trk(tmp)
+
+    expect_length(result, 2)
+    expect_identical(nrow(result[[1]]), 2L)
+    expect_identical(nrow(result[[2]]), 2L)
+  })
+
   it("handles TRK with scalars", {
     tmp <- withr::local_tempfile(fileext = ".trk")
     con <- file(tmp, "wb")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -43,6 +43,19 @@ describe("as_verbosity", {
     expect_identical(as_verbosity(NA), 1L)
     expect_identical(as_verbosity("bad"), 1L)
   })
+
+  it("accepts spelled-out boolean strings", {
+    expect_identical(as_verbosity("false"), 0L)
+    expect_identical(as_verbosity("FALSE"), 0L)
+    expect_identical(as_verbosity("off"), 0L)
+    expect_identical(as_verbosity("true"), 1L)
+    expect_identical(as_verbosity("on"), 1L)
+  })
+
+  it("still reads numeric strings as levels", {
+    expect_identical(as_verbosity("0"), 0L)
+    expect_identical(as_verbosity("2"), 2L)
+  })
 })
 
 describe("get_verbose", {
@@ -64,6 +77,15 @@ describe("get_verbose", {
     withr::local_options(ggseg.extra.verbose = NULL)
     withr::local_envvar(GGSEG_EXTRA_VERBOSE = "0")
     expect_identical(get_verbose(), 0L)
+  })
+
+  it("parses spelled-out boolean env vars as silent/standard", {
+    withr::local_options(ggseg.extra.verbose = NULL)
+    withr::local_envvar(GGSEG_EXTRA_VERBOSE = "false")
+    expect_identical(get_verbose(), 0L)
+
+    withr::local_envvar(GGSEG_EXTRA_VERBOSE = "true")
+    expect_identical(get_verbose(), 1L)
   })
 
   it("option takes precedence over envvar", {
@@ -129,6 +151,17 @@ describe("get_cleanup", {
     withr::local_options(ggseg.extra.cleanup = NULL)
     withr::local_envvar(GGSEG_EXTRA_CLEANUP = NA)
     expect_true(get_cleanup())
+  })
+
+  it("accepts string spellings from explicit and option channels", {
+    expect_true(get_cleanup("yes"))
+    expect_false(get_cleanup("no"))
+
+    withr::local_options(ggseg.extra.cleanup = "1")
+    expect_true(get_cleanup())
+
+    withr::local_options(ggseg.extra.cleanup = "off")
+    expect_false(get_cleanup())
   })
 })
 

--- a/tests/testthat/test-utils_snapshot.R
+++ b/tests/testthat/test-utils_snapshot.R
@@ -425,6 +425,15 @@ describe("get_contours", {
     expect_null(result)
   })
 
+  it("returns NULL without erroring when the raster max is NA", {
+    local_mocked_bindings(
+      global = function(x, ...) data.frame(max = NA_real_),
+      .package = "terra"
+    )
+
+    expect_null(get_contours("fake_raster", max_val = 255))
+  })
+
   it("processes raster when max >= max_val", {
     .cap$as_polygons_called <- FALSE
 
@@ -540,6 +549,58 @@ describe("get_contours full processing path", {
     result <- get_contours(rast_obj, max_val = 255)
 
     expect_s3_class(result, "sf")
+  })
+
+  it("keeps valid contours when only some geometries are empty", {
+    mixed_sf <- sf::st_sf(
+      id = c(1, 2),
+      geometry = sf::st_sfc(
+        sf::st_polygon(list(matrix(
+          c(0, 0, 1, 0, 1, 1, 0, 1, 0, 0),
+          ncol = 2,
+          byrow = TRUE
+        ))),
+        sf::st_polygon()
+      )
+    )
+    mock_result_sf <- sf::st_sf(
+      geometry = sf::st_sfc(sf::st_multipolygon(list(list(matrix(
+        c(0, 0, 1, 0, 1, 1, 0, 1, 0, 0),
+        ncol = 2,
+        byrow = TRUE
+      )))))
+    )
+
+    rast_obj <- structure(list(), class = "mock_rast4")
+    assign("[<-.mock_rast4", function(x, i, value) x, envir = globalenv())
+    assign("[.mock_rast4", function(x, i) x, envir = globalenv())
+    withr::defer({
+      rm("[<-.mock_rast4", envir = globalenv())
+      rm("[.mock_rast4", envir = globalenv())
+    })
+
+    .cap$to_coords_nrow <- NULL
+    local_mocked_bindings(
+      global = function(x, ...) data.frame(max = 255),
+      as.polygons = function(...) mixed_sf,
+      .package = "terra"
+    )
+    local_mocked_bindings(
+      st_as_sf = function(...) mixed_sf,
+      .package = "sf"
+    )
+    local_mocked_bindings(
+      to_coords = function(coords, n) {
+        .cap$to_coords_nrow <- nrow(coords)
+        coords
+      },
+      coords2sf = function(coords, limits) mock_result_sf
+    )
+
+    result <- get_contours(rast_obj, max_val = 255)
+
+    expect_s3_class(result, "sf")
+    expect_identical(.cap$to_coords_nrow, 1L)
   })
 
   it("returns NULL when all contours are empty geometries", {


### PR DESCRIPTION
## Summary

Resolves 12 correctness defects surfaced by a full-codebase critical review — **2 Blocking** (both break documented workflows on valid input) and **10 Required**. Every fix ships with a regression test. No architectural changes; each fix is localized.

### Blocking
- **Cerebellar float-volume crash** — `sample_volume_at_surface()` forced an integer `vapply()` template, so a double-typed parcellation (e.g. the SUIT volume `transform_mni_to_suit()` writes) aborted `create_cerebellar_from_volume()` with a `vapply` type error. Now coerces the label volume to integer before sampling.
- **`read_trk()` empty on spec-valid files** — the reader trusted the header track count; the TrackVis spec uses `0` to mean "read to EOF", so such files silently produced an empty atlas. Now reads to EOF, using a positive count as an upper bound.

### Required
- `parse_continuous_values()` aborted with `'breaks' are not unique` on tied continuous maps → dedupe quantile breaks + warn; clear error on an all‑medial‑wall hemisphere.
- `mri_info_matrix()` passed an unquoted path to `system2` (which doesn't quote args) → `shQuote()`; deep‑nuclei meshing now works for paths with spaces.
- `detect_tract_coord_space()` flattened a list of matrices into a numeric vector → in‑memory voxel‑space tracts were misdetected as RAS and mislocated. Now flattens robustly.
- `load_vox2ras_matrix()` silently fell back to a crude origin‑centering heuristic → now warns. **Also fixes a latent bug it exposed:** the mgz branch read a non‑existent `$vox2ras` field (always `NULL`), so mgz tract templates *always* hit the heuristic — now uses `mghheader.vox2ras()`.
- `create_subcortical_from_volume()` named `.nii.gz` inputs `aseg.nii` → now `aseg`.
- `get_contours()` crashed on an all‑NA raster max and discarded all contours when one geometry was empty → NA guard + keep valid contours.
- `probe_raster_max()` crashed on an all‑NA raster → `is.finite()` guard.
- `combine_region_contours()` gave a cryptic `dplyr` error when no region produced a contour → clear abort.
- Verbosity/boolean options parse spelled‑out strings (`"false"`, `"yes"`, `"on"`) consistently across the explicit, option, and env‑var channels (`GGSEG_EXTRA_VERBOSE=false` now silences output).

## Test Plan
- `devtools::test()` — **0 failures**, 10 expected FreeSurfer/ImageMagick skips
- `lintr::lint_package()` — 0 lints; `air format` — no changes
- `devtools::document()` — no NAMESPACE/`man/` drift (all new helpers are `@noRd`)
- 21 new regression tests added across the 8 affected source areas

Review conducted with the [critical-code-reviewer skill](https://github.com/posit-dev/skills/blob/main/posit-dev/critical-code-reviewer/SKILL.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)