### PR TITLE
fix: address suggestion-tier review findings (stacked on #103)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg.extra
 Title: Create Brain Atlases for the 'ggsegverse' Plotting Ecosystem
-Version: 1.9.9.9007
+Version: 1.9.9.9008
 Authors@R: c(
     person(
         given = "Athanasia Mo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,35 @@
+# ggseg.extra 1.9.9.9008
+
+## Minor improvements and fixes
+
+- Tract 2D projections now reuse the same centerline as the 3D tube (built with
+  the configured `n_points` / `centerline_method`) instead of recomputing a
+  different 50-point mean centerline, so the two representations agree.
+- `read_tractography()` reads `.tck` files without the previous quadratic
+  slow-down on large bundles.
+- `create_tract_from_tractography()` validates `tube_segments` (integer >= 3),
+  and degenerate leading tract segments no longer yield `NaN` tube vertices.
+- Cerebellar trilinear resampling skips non-finite deformation coordinates
+  rather than raising an error, and a deep nucleus that cannot be converted to
+  polygons is now reported instead of silently dropped.
+- `create_wholebrain_from_volume()` splits cortex at the correct (1-based)
+  midline voxel; the left/right boundary was previously off by one voxel.
+- Reading a FreeSurfer LUT warns about malformed lines; `write_lut()`
+  validates its input; `read_lut()`/`read_dpv()` fail with clear messages on
+  malformed headers, and `read_dpv()` handles zero-face surfaces.
+- CIFTI files with more than one label map warn that only the first is used.
+- Annotation files whose colour table already defines an "unknown" region no
+  longer produce a duplicate `unknown` label.
+- Contour extraction reports a clear error when no region yields a contour
+  instead of a cryptic downstream failure.
+- Subcortical mesh tessellation honors the requested verbosity inside parallel
+  workers.
+- Reading a subcortical surface surfaces the underlying conversion error when
+  the fallback reader is unavailable, and the interactive atlas preview warns
+  on 3D render failures instead of failing silently.
+- `setup_atlas_repo()` no longer rewrites files under a template's `.git`
+  directory and reports failed file copies/renames.
+
 # ggseg.extra 1.9.9.9007
 
 ## Bug fixes
@@ -37,36 +69,6 @@
   `GGSEG_EXTRA_VERBOSE=false` now silences output, and string values such as
   `"yes"` or `"1"` are honored across the explicit, option, and
   environment-variable channels.
-
-## Minor improvements and fixes
-
-- Tract 2D projections now reuse the same centerline as the 3D tube (built with
-  the configured `n_points` / `centerline_method`) instead of recomputing a
-  different 50-point mean centerline, so the two representations agree.
-- `read_tractography()` reads `.tck` files without the previous quadratic
-  slow-down on large bundles.
-- `create_tract_from_tractography()` validates `tube_segments` (integer >= 3),
-  and degenerate leading tract segments no longer yield `NaN` tube vertices.
-- Cerebellar trilinear resampling skips non-finite deformation coordinates
-  rather than raising an error, and a deep nucleus that cannot be converted to
-  polygons is now reported instead of silently dropped.
-- `create_wholebrain_from_volume()` splits cortex at the correct (1-based)
-  midline voxel; the left/right boundary was previously off by one voxel.
-- Reading a FreeSurfer LUT warns about malformed lines; `write_lut()`
-  validates its input; `read_lut()`/`read_dpv()` fail with clear messages on
-  malformed headers, and `read_dpv()` handles zero-face surfaces.
-- CIFTI files with more than one label map warn that only the first is used.
-- Annotation files whose colour table already defines an "unknown" region no
-  longer produce a duplicate `unknown` label.
-- Contour extraction reports a clear error when no region yields a contour
-  instead of a cryptic downstream failure.
-- Subcortical mesh tessellation honors the requested verbosity inside parallel
-  workers.
-- Reading a subcortical surface surfaces the underlying conversion error when
-  the fallback reader is unavailable, and the interactive atlas preview warns
-  on 3D render failures instead of failing silently.
-- `setup_atlas_repo()` no longer rewrites files under a template's `.git`
-  directory and reports failed file copies/renames.
 
 # ggseg.extra 1.9.9.9005
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,36 @@
   `"yes"` or `"1"` are honored across the explicit, option, and
   environment-variable channels.
 
+## Minor improvements and fixes
+
+- Tract 2D projections now reuse the same centerline as the 3D tube (built with
+  the configured `n_points` / `centerline_method`) instead of recomputing a
+  different 50-point mean centerline, so the two representations agree.
+- `read_tractography()` reads `.tck` files without the previous quadratic
+  slow-down on large bundles.
+- `create_tract_from_tractography()` validates `tube_segments` (integer >= 3),
+  and degenerate leading tract segments no longer yield `NaN` tube vertices.
+- Cerebellar trilinear resampling skips non-finite deformation coordinates
+  rather than raising an error, and a deep nucleus that cannot be converted to
+  polygons is now reported instead of silently dropped.
+- `create_wholebrain_from_volume()` splits cortex at the correct (1-based)
+  midline voxel; the left/right boundary was previously off by one voxel.
+- Reading a FreeSurfer LUT warns about malformed lines; `write_lut()`
+  validates its input; `read_lut()`/`read_dpv()` fail with clear messages on
+  malformed headers, and `read_dpv()` handles zero-face surfaces.
+- CIFTI files with more than one label map warn that only the first is used.
+- Annotation files whose colour table already defines an "unknown" region no
+  longer produce a duplicate `unknown` label.
+- Contour extraction reports a clear error when no region yields a contour
+  instead of a cryptic downstream failure.
+- Subcortical mesh tessellation honors the requested verbosity inside parallel
+  workers.
+- Reading a subcortical surface surfaces the underlying conversion error when
+  the fallback reader is unavailable, and the interactive atlas preview warns
+  on 3D render failures instead of failing silently.
+- `setup_atlas_repo()` no longer rewrites files under a template's `.git`
+  directory and reports failed file copies/renames.
+
 # ggseg.extra 1.9.9.9005
 
 ## Bug fixes

--- a/R/atlas_cerebellar.R
+++ b/R/atlas_cerebellar.R
@@ -669,40 +669,45 @@ resample_trilinear <- function(result, vox_coords, mni_arr, mni_dims) {
     "Trilinear interpolation (may be slow for large volumes)"
   )
   for (i in seq_len(nrow(vox_coords))) {
-    vi <- vox_coords[i, ]
-    if (
-      any(vi < 1) ||
-        vi[1] > mni_dims[1] ||
-        vi[2] > mni_dims[2] ||
-        vi[3] > mni_dims[3]
-    ) {
-      next
+    val <- trilinear_sample(vox_coords[i, ], mni_arr, mni_dims)
+    if (!is.null(val)) {
+      result[i] <- val
     }
-
-    x0 <- floor(vi[1])
-    x1 <- min(x0 + 1L, mni_dims[1])
-    y0 <- floor(vi[2])
-    y1 <- min(y0 + 1L, mni_dims[2])
-    z0 <- floor(vi[3])
-    z1 <- min(z0 + 1L, mni_dims[3])
-    xd <- vi[1] - x0
-    yd <- vi[2] - y0
-    zd <- vi[3] - z0
-
-    result[i] <-
-      mni_arr[x0, y0, z0] *
-      (1 - xd) *
-      (1 - yd) *
-      (1 - zd) +
-      mni_arr[x1, y0, z0] * xd * (1 - yd) * (1 - zd) +
-      mni_arr[x0, y1, z0] * (1 - xd) * yd * (1 - zd) +
-      mni_arr[x0, y0, z1] * (1 - xd) * (1 - yd) * zd +
-      mni_arr[x1, y1, z0] * xd * yd * (1 - zd) +
-      mni_arr[x0, y1, z1] * (1 - xd) * yd * zd +
-      mni_arr[x1, y0, z1] * xd * (1 - yd) * zd +
-      mni_arr[x1, y1, z1] * xd * yd * zd
   }
   result
+}
+
+#' Trilinearly sample one voxel coordinate, or `NULL` when out of bounds or NA
+#'
+#' The `anyNA()` check comes first so the bounds comparisons never run on a
+#' non-finite coordinate (which would make `if ()` error).
+#' @noRd
+trilinear_sample <- function(vi, mni_arr, mni_dims) {
+  if (anyNA(vi) || any(vi < 1 | vi > mni_dims)) {
+    return(NULL)
+  }
+
+  x0 <- floor(vi[1])
+  x1 <- min(x0 + 1L, mni_dims[1])
+  y0 <- floor(vi[2])
+  y1 <- min(y0 + 1L, mni_dims[2])
+  z0 <- floor(vi[3])
+  z1 <- min(z0 + 1L, mni_dims[3])
+  xd <- vi[1] - x0
+  yd <- vi[2] - y0
+  zd <- vi[3] - z0
+
+  mni_arr[x0, y0, z0] *
+    (1 - xd) *
+    (1 - yd) *
+    (1 - zd) +
+    mni_arr[x1, y0, z0] * xd * (1 - yd) * (1 - zd) +
+    mni_arr[x0, y1, z0] * (1 - xd) * yd * (1 - zd) +
+    mni_arr[x0, y0, z1] * (1 - xd) * (1 - yd) * zd +
+    mni_arr[x1, y1, z0] * xd * yd * (1 - zd) +
+    mni_arr[x0, y1, z1] * (1 - xd) * yd * zd +
+    mni_arr[x1, y0, z1] * xd * (1 - yd) * zd +
+    mni_arr[x1, y1, z1] * xd * yd * zd
 }
 
 
@@ -990,6 +995,10 @@ build_deep_nucleus_sf <- function(vol, idx, label) {
     error = function(e) NULL
   )
   if (is.null(polys)) {
+    cli::cli_warn(c(
+      "Could not polygonise deep nucleus {.val {label}}; dropping it.",
+      "i" = "{.pkg terra} failed to extract polygons from its voxel mask."
+    ))
     return(NULL)
   }
 

--- a/R/atlas_geometry.R
+++ b/R/atlas_geometry.R
@@ -192,8 +192,7 @@ map_region_contours <- function(regions, max_val, vertex_size_limits, step) {
       result <- get_contours(
         r,
         max_val = max_val,
-        vertex_size_limits = vertex_size_limits,
-        verbose = get_verbose() # nolint: object_usage_linter
+        vertex_size_limits = vertex_size_limits
       )
       p()
       result
@@ -414,22 +413,24 @@ simplify_sf_topology <- function(sf_data, keep = 0.05) {
     NULL
   }
 
-  if (!is.null(group_col)) {
-    groups <- unique(sf_data[[group_col]])
-    if (length(groups) > 1) {
-      parts <- lapply(groups, function(g) {
-        group_sf <- sf_data[sf_data[[group_col]] == g, , drop = FALSE]
-        rmapshaper::ms_simplify(group_sf, keep = keep, keep_shapes = TRUE)
-      })
-      sf_data <- do.call(rbind, parts)
-      if (".view_group" %in% names(sf_data)) {
-        sf_data$.view_group <- NULL
-      }
-      return(sf::st_make_valid(sf_data))
-    }
+  multi_group <- !is.null(group_col) &&
+    length(unique(sf_data[[group_col]])) > 1
+
+  if (multi_group) {
+    parts <- lapply(unique(sf_data[[group_col]]), function(g) {
+      group_sf <- sf_data[sf_data[[group_col]] == g, , drop = FALSE]
+      rmapshaper::ms_simplify(group_sf, keep = keep, keep_shapes = TRUE)
+    })
+    sf_data <- do.call(rbind, parts)
+  } else {
+    sf_data <- rmapshaper::ms_simplify(sf_data, keep = keep, keep_shapes = TRUE)
   }
 
-  sf_data <- rmapshaper::ms_simplify(sf_data, keep = keep, keep_shapes = TRUE)
+  # Drop the temporary grouping column in both paths so it never leaks into
+  # the returned atlas (a stray column breaks rbind() in smooth_sf_subset()).
+  if (".view_group" %in% names(sf_data)) {
+    sf_data$.view_group <- NULL
+  }
   sf::st_make_valid(sf_data)
 }
 

--- a/R/atlas_repo.R
+++ b/R/atlas_repo.R
@@ -253,10 +253,13 @@ populate_from_template <- function(path, template_dir, atlas_name, repo_name) {
 
   pkg_file <- as.character(fs::path(path, "R", "REPO-package.R"))
   if (file.exists(pkg_file)) {
-    file.rename(
+    renamed <- file.rename(
       pkg_file,
       as.character(fs::path(path, "R", paste0(repo_name, "-package.R")))
     )
+    if (!renamed) {
+      cli::cli_warn("Could not rename {.file REPO-package.R} to {repo_name}")
+    }
   }
 
   replace_template_placeholders(path, atlas_name)
@@ -307,7 +310,9 @@ copy_template_files <- function(path, template_dir) {
     dst_name <- gsub("(^|/)dot-", "\\1.", f)
     dst <- as.character(fs::path(path, dst_name))
     mkdir(dirname(dst))
-    file.copy(src, dst, overwrite = TRUE)
+    if (!file.copy(src, dst, overwrite = TRUE)) {
+      cli::cli_warn("Could not copy template file {.file {f}}")
+    }
   }
 
   invisible(path)
@@ -324,7 +329,7 @@ replace_template_placeholders <- function(path, atlas_name) {
     all.files = TRUE
   )
   all_files <- all_files[
-    !grepl("^\\.git/", basename(all_files)) &
+    !grepl("(^|/)\\.git(/|$)", all_files) &
       !grepl(
         "\\.(png|jpg|jpeg|gif|ico|rda|RData|rds)$",
         all_files,

--- a/R/atlas_subcortical.R
+++ b/R/atlas_subcortical.R
@@ -509,7 +509,7 @@ subcort_resolve_labels <- function(config, dirs) {
 
   vol <- read_volume(config$input_volume)
   vol_labels <- unique(c(vol))
-  vol_labels <- vol_labels[vol_labels != 0]
+  vol_labels <- vol_labels[!is.na(vol_labels) & vol_labels != 0]
   colortable <- colortable[colortable$idx %in% vol_labels, ]
 
   colortable$label <- sanitize_label(colortable$label)

--- a/R/atlas_tracts.R
+++ b/R/atlas_tracts.R
@@ -305,7 +305,18 @@ validate_tract_config <- function(
     c("mean", "medoid")
   )
   config$tube_radius <- tube_radius
-  config$tube_segments <- tube_segments
+  if (
+    !is.numeric(tube_segments) ||
+      length(tube_segments) != 1L ||
+      is.na(tube_segments) ||
+      tube_segments < 3
+  ) {
+    cli::cli_abort(c(
+      "{.arg tube_segments} must be a single integer >= 3.",
+      "x" = "Got: {.val {tube_segments}}"
+    ))
+  }
+  config$tube_segments <- as.integer(tube_segments)
   config$n_points <- n_points
   config$density_radius_range <- c(0.2, 1.0)
   config$tract_radius <- 3
@@ -495,7 +506,6 @@ tract_run_snapshots <- function(config, dirs, step1, input_aseg, slabs, files) {
   }
 
   result <- tract_create_snapshots(
-    step1$streamlines_data,
     step1$centerlines_df,
     input_aseg,
     slabs,

--- a/R/atlas_wholebrain.R
+++ b/R/atlas_wholebrain.R
@@ -1602,7 +1602,9 @@ wholebrain_prepare_subcortical_volume <- function(
   }
   cortical_mask <- arr %in% cortical_idx
   xform <- RNifti::xform(vol)
-  x0_voxel <- round(solve(xform, c(0, 0, 0, 1))[1])
+  # xform maps 0-based voxel indices to world; slice.index() is 1-based, so
+  # shift the midline voxel to 1-based before comparing.
+  x0_voxel <- round(solve(xform, c(0, 0, 0, 1))[1]) + 1L
   x_idx <- slice.index(arr, 1)
   left_is_high <- xform[1, 1] < 0
   if (left_is_high) {

--- a/R/mesh_projection.R
+++ b/R/mesh_projection.R
@@ -82,7 +82,7 @@ build_vertex_label_vector <- function(vertices_df, n_vertices, hemi_short) {
 
   for (i in seq_len(nrow(vertices_df))) {
     lbl <- vertices_df$label[i]
-    if (!startsWith(lbl, prefix)) {
+    if (is.na(lbl) || !startsWith(lbl, prefix)) {
       next
     }
     idx <- vertices_df$vertices[[i]] + 1L

--- a/R/read_write.R
+++ b/R/read_write.R
@@ -80,10 +80,17 @@ read_lut <- function(path) {
     "\\s+(\\d+)\\s+(\\d+)(?:\\s+(\\w+))?\\s*$"
   )
   parsed <- regmatches(lines, regexec(lut_pattern, lines))
-  rows <- lapply(parsed, function(m) {
-    if (length(m) == 0) {
-      return(NULL)
-    }
+  matched <- lengths(parsed) > 0
+
+  dropped <- lines[!matched & !startsWith(lines, "#")]
+  if (length(dropped) > 0) {
+    cli::cli_warn(c(
+      "Skipped {length(dropped)} unparseable line{?s} in {.path {path}}",
+      "i" = "First skipped: {.val {dropped[1]}}"
+    ))
+  }
+
+  rows <- lapply(parsed[matched], function(m) {
     data.frame(
       idx = as.integer(m[2]),
       label = trimws(m[3]),
@@ -95,7 +102,11 @@ read_lut <- function(path) {
       stringsAsFactors = FALSE
     )
   })
-  result <- do.call(rbind, Filter(Negate(is.null), rows))
+  if (length(rows) == 0) {
+    cli::cli_abort("No valid LUT entries found in {.path {path}}")
+  }
+
+  result <- do.call(rbind, rows)
   if (all(is.na(result$type))) {
     result$type <- NULL
   }
@@ -131,10 +142,19 @@ read_ctab <- function(path) {
 #' out <- tempfile()
 #' write_lut(ct, out)
 write_lut <- function(x, path) {
-  lls <- apply(x, 1, function(row) {
-    lut_line(row[1], row[2], row[3], row[4], row[5], row[6])
-  })
-  lls[length(lls) + 1] <- ""
+  if (!is_lut(x)) {
+    cli::cli_abort(c(
+      "{.arg x} must be a valid LUT",
+      "i" = "Expected columns: {.field idx}, {.field label}, {.field R}, \\
+             {.field G}, {.field B}, {.field A}"
+    ))
+  }
+  lls <- vapply(
+    seq_len(nrow(x)),
+    function(i) lut_line(x$idx[i], x$label[i], x$R[i], x$G[i], x$B[i], x$A[i]),
+    character(1)
+  )
+  lls <- c(lls, "")
   writeLines(lls, path)
   invisible(lls)
 }
@@ -616,7 +636,13 @@ cifti_hemi_info <- function(cii) {
 #' Build the region lookup table from CIFTI label metadata
 #' @noRd
 cifti_label_regions <- function(cii) {
-  label_table <- cii$meta$cifti$labels[[1]]
+  label_maps <- cii$meta$cifti$labels
+  if (length(label_maps) > 1) {
+    cli::cli_warn(
+      "CIFTI file has {length(label_maps)} label maps; using only the first."
+    )
+  }
+  label_table <- label_maps[[1]]
 
   data.frame(
     code = label_table$Key,
@@ -888,13 +914,26 @@ extract_vertex_regions <- function(
   unlabeled_vertices <- setdiff(all_vertex_indices, labeled_vertices)
 
   if (length(unlabeled_vertices) > 0) {
-    all_data[[n_regions + 1L]] <- tibble(
-      hemi = hemi,
-      region = "unknown",
-      label = paste(hemi_short, "unknown", sep = "_"),
-      colour = "#BEBEBE",
-      vertices = list(unlabeled_vertices)
+    existing_unknown <- Position(
+      function(d) identical(d$region, "unknown"),
+      all_data,
+      nomatch = 0L
     )
+    if (existing_unknown > 0L) {
+      merged <- sort(unique(c(
+        all_data[[existing_unknown]]$vertices[[1]],
+        unlabeled_vertices
+      )))
+      all_data[[existing_unknown]]$vertices <- list(merged)
+    } else {
+      all_data[[n_regions + 1L]] <- tibble(
+        hemi = hemi,
+        region = "unknown",
+        label = paste(hemi_short, "unknown", sep = "_"),
+        colour = "#BEBEBE",
+        vertices = list(unlabeled_vertices)
+      )
+    }
   }
 
   all_data
@@ -951,7 +990,15 @@ read_label_vertices <- function(label_file) {
 #' @importFrom utils read.table
 read_dpv <- function(path) {
   header <- readLines(path, n = 2)
-  counts <- as.integer(strsplit(trimws(header[2]), "\\s+")[[1]])
+  counts <- suppressWarnings(as.integer(strsplit(trimws(header[2]), "\\s+")[[
+    1
+  ]]))
+  if (length(counts) < 2 || anyNA(counts[1:2])) {
+    cli::cli_abort(c(
+      "Could not read vertex/face counts from {.path {path}}",
+      "i" = "Expected two integers on the second line."
+    ))
+  }
   n_vertices <- counts[1]
   n_faces <- counts[2]
 
@@ -961,7 +1008,7 @@ read_dpv <- function(path) {
   names(vertices) <- c("x", "y", "z")
   row.names(vertices) <- NULL
 
-  faces <- data[(n_vertices + 1):(n_vertices + n_faces), 1:3, drop = FALSE]
+  faces <- data[seq_len(n_faces) + n_vertices, 1:3, drop = FALSE]
   names(faces) <- c("i", "j", "k")
   row.names(faces) <- NULL
 

--- a/R/snapshots.R
+++ b/R/snapshots.R
@@ -85,6 +85,13 @@ volume_projection <- function(
     )
   }
 
+  if (end < start) {
+    cli::cli_abort(c(
+      "Projection range end ({end}) is before start ({start}).",
+      "i" = "Provide a range where {.arg end} is at least {.arg start}."
+    ))
+  }
+
   # nolint start: commas_linter.
   sub_vol <- switch(
     view,

--- a/R/subcortical_geometry.R
+++ b/R/subcortical_geometry.R
@@ -268,6 +268,8 @@ decimate_mesh <- function(mesh, percent = 0.5) {
 read_fs_surface <- function(file, verbose = get_verbose()) {
   dpv_file <- paste0(file, ".dpv")
 
+  # nolint next: object_usage_linter.
+  surf2asc_error <- NULL
   result <- tryCatch(
     {
       surf2asc(file, dpv_file, verbose = verbose)
@@ -282,7 +284,10 @@ read_fs_surface <- function(file, verbose = get_verbose()) {
 
       list(vertices = vertices, faces = faces)
     },
-    error = function(e) NULL
+    error = function(e) {
+      surf2asc_error <<- conditionMessage(e)
+      NULL
+    }
   )
 
   if (!is.null(result)) {
@@ -292,7 +297,9 @@ read_fs_surface <- function(file, verbose = get_verbose()) {
   if (!requireNamespace("freesurferformats", quietly = TRUE)) {
     cli::cli_abort(c(
       "Failed to read surface file: {.path {file}}",
-      "i" = "FreeSurfer conversion failed and freesurferformats not available"
+      "i" = "FreeSurfer conversion failed and {.pkg freesurferformats} \\
+             not available",
+      "x" = "Conversion error: {surf2asc_error}"
     ))
   }
 

--- a/R/subcortical_geometry.R
+++ b/R/subcortical_geometry.R
@@ -268,9 +268,9 @@ decimate_mesh <- function(mesh, percent = 0.5) {
 read_fs_surface <- function(file, verbose = get_verbose()) {
   dpv_file <- paste0(file, ".dpv")
 
-  # nolint next: object_usage_linter.
-  surf2asc_error <- NULL
-  result <- tryCatch(
+  # On success this is the mesh; on failure it is the error message, so the
+  # reason for falling back to freesurferformats survives the tryCatch.
+  surf2asc_result <- tryCatch(
     {
       surf2asc(file, dpv_file, verbose = verbose)
       mesh <- read_dpv(dpv_file)
@@ -284,14 +284,11 @@ read_fs_surface <- function(file, verbose = get_verbose()) {
 
       list(vertices = vertices, faces = faces)
     },
-    error = function(e) {
-      surf2asc_error <<- conditionMessage(e)
-      NULL
-    }
+    error = function(e) conditionMessage(e)
   )
 
-  if (!is.null(result)) {
-    return(result)
+  if (!is.character(surf2asc_result)) {
+    return(surf2asc_result)
   }
 
   if (!requireNamespace("freesurferformats", quietly = TRUE)) {
@@ -299,7 +296,7 @@ read_fs_surface <- function(file, verbose = get_verbose()) {
       "Failed to read surface file: {.path {file}}",
       "i" = "FreeSurfer conversion failed and {.pkg freesurferformats} \\
              not available",
-      "x" = "Conversion error: {surf2asc_error}"
+      "x" = "Conversion error: {surf2asc_result}"
     ))
   }
 

--- a/R/subcortical_steps.R
+++ b/R/subcortical_steps.R
@@ -65,7 +65,7 @@ subcort_mesh_one <- function(
       volume_file = input_volume,
       label_id = label_id,
       output_dir = dirs$meshes,
-      verbose = get_verbose(), # nolint: object_usage_linter
+      verbose = verbose,
       skip_existing = skip_existing
     ),
     error = function(e) {
@@ -101,8 +101,12 @@ subcort_decimate_meshes <- function(meshes_list, decimate, verbose) {
         function(m) nrow(m$faces),
         integer(1)
       ))
-      # fmt: skip
-      pct <- round(new_faces / orig_faces * 100) # nolint
+      # nolint next: object_usage_linter.
+      pct <- if (orig_faces > 0) {
+        round(new_faces / orig_faces * 100)
+      } else {
+        NA_integer_
+      }
       cli::cli_alert_success(
         "Reduced from {orig_faces} to {new_faces} faces ({pct}%)"
       )

--- a/R/tract_geometry.R
+++ b/R/tract_geometry.R
@@ -205,7 +205,7 @@ generate_tube_mesh <- function(centerline, radius = 0.5, segments = 8) {
 #' @noRd
 tube_ring_vertices <- function(centerline, radius, frames, segments) {
   n_points <- nrow(centerline)
-  angles <- seq(0, 2 * pi, length.out = segments + 1)[1:segments]
+  angles <- seq(0, 2 * pi, length.out = segments + 1)[seq_len(segments)]
 
   grid <- expand.grid(j = seq_len(segments), i = seq_len(n_points))
   cos_a <- cos(angles[grid$j])
@@ -260,7 +260,15 @@ compute_parallel_transport_frames <- function(curve) {
   t0 <- tangents[1, ]
   arbitrary <- if (abs(t0[1]) < 0.9) c(1, 0, 0) else c(0, 1, 0)
   n0 <- cross_product(t0, arbitrary)
-  n0 <- n0 / sqrt(sum(n0^2))
+  n0_norm <- sqrt(sum(n0^2))
+  if (n0_norm < 1e-10) {
+    # Degenerate leading tangent (e.g. a duplicated first point): any unit
+    # vector works as the initial normal. Use a fixed one rather than dividing
+    # by ~0 and propagating NaN through every tube vertex.
+    n0 <- c(1, 0, 0)
+    n0_norm <- 1
+  }
+  n0 <- n0 / n0_norm
 
   normals <- matrix(0, nrow = n, ncol = 3)
   binormals <- matrix(0, nrow = n, ncol = 3)

--- a/R/tract_io.R
+++ b/R/tract_io.R
@@ -120,7 +120,7 @@ read_tck <- function(file) {
   endian <- if (grepl("BE$", datatype)) "big" else "little"
 
   streamlines <- list()
-  current_streamline <- new_tck_streamline()
+  points <- list()
 
   while (TRUE) {
     coords <- readBin(con, "double", 3, size = byte_size, endian = endian)
@@ -133,18 +133,18 @@ read_tck <- function(file) {
     }
 
     if (all(is.nan(coords))) {
-      if (nrow(current_streamline) > 0) {
-        streamlines[[length(streamlines) + 1]] <- current_streamline
-        current_streamline <- new_tck_streamline()
+      if (length(points) > 0) {
+        streamlines[[length(streamlines) + 1L]] <- tck_points_to_matrix(points)
+        points <- list()
       }
       next
     }
 
-    current_streamline <- rbind(current_streamline, coords)
+    points[[length(points) + 1L]] <- coords
   }
 
-  if (nrow(current_streamline) > 0) {
-    streamlines[[length(streamlines) + 1]] <- current_streamline
+  if (length(points) > 0) {
+    streamlines[[length(streamlines) + 1L]] <- tck_points_to_matrix(points)
   }
 
   streamlines
@@ -193,10 +193,10 @@ tck_datatype_byte_size <- function(datatype) {
 }
 
 
-#' Create an empty TCK streamline matrix with xyz columns
+#' Bind collected TCK points into an x/y/z coordinate matrix
 #' @noRd
-new_tck_streamline <- function() {
-  current_streamline <- matrix(ncol = 3, nrow = 0)
-  colnames(current_streamline) <- c("x", "y", "z")
-  current_streamline
+tck_points_to_matrix <- function(points) {
+  sl <- do.call(rbind, points)
+  colnames(sl) <- c("x", "y", "z")
+  sl
 }

--- a/R/tract_steps.R
+++ b/R/tract_steps.R
@@ -167,7 +167,6 @@ tract_build_core <- function(meshes_list, colours, tract_names) {
 
 #' @noRd
 tract_create_snapshots <- function(
-  streamlines_data,
   centerlines_df,
   input_aseg,
   slabs,
@@ -186,9 +185,10 @@ tract_create_snapshots <- function(
   cortex_slices <- create_cortex_slices(slabs, dims)
 
   tract_labels <- centerlines_df$label
+  centerlines <- stats::setNames(centerlines_df$points, tract_labels)
 
   tract_volumes <- tract_volume_map(
-    streamlines_data,
+    centerlines,
     tract_labels,
     input_aseg,
     tract_radius,
@@ -223,7 +223,7 @@ tract_create_snapshots <- function(
 #' Rasterise every tract centerline into its own label volume
 #' @noRd
 tract_volume_map <- function(
-  streamlines_data,
+  centerlines,
   tract_labels,
   input_aseg,
   tract_radius,
@@ -234,14 +234,11 @@ tract_volume_map <- function(
   tract_volumes <- safe_future_pmap(
     list(label = tract_labels, i = seq_along(tract_labels)),
     function(label, i) {
-      centerline <- streamlines_data[[label]]
-
-      if (is.list(centerline) && !is.matrix(centerline)) {
-        centerline <- extract_centerline(centerline, n_points = 50)
-      }
-
+      # Reuse the centerline computed for the 3D tube (with the configured
+      # n_points / centerline_method) so the 2D projection matches it exactly
+      # instead of recomputing a different one here.
       vol <- streamlines_to_volume(
-        centerline = centerline,
+        centerline = centerlines[[label]],
         template_file = input_aseg,
         label_value = i,
         radius = tract_radius,
@@ -254,7 +251,7 @@ tract_volume_map <- function(
     .options = furrr_options(
       packages = "ggseg.extra",
       globals = c(
-        "streamlines_data",
+        "centerlines",
         "input_aseg",
         "tract_radius",
         "coords_are_voxels",

--- a/R/utils.R
+++ b/R/utils.R
@@ -212,7 +212,9 @@ preview_atlas <- function(atlas) {
         prompt_user("3D preview. Press Enter to continue")
       }
     },
-    error = function(e) NULL
+    error = function(e) {
+      cli::cli_alert_warning("3D preview failed: {conditionMessage(e)}")
+    }
   )
 
   invisible(atlas)

--- a/R/utils_atlas.R
+++ b/R/utils_atlas.R
@@ -3,8 +3,8 @@
 #' @noRd
 #' @importFrom tools file_ext file_path_sans_ext
 derive_atlas_name <- function(filepath) {
-  if (length(filepath) == 0 || is.na(filepath)) {
-    cli::cli_abort("No input file provided to derive atlas name from")
+  if (length(filepath) != 1L || is.na(filepath)) {
+    cli::cli_abort("A single input file is required to derive an atlas name")
   }
   name <- basename(filepath)
   ext <- tools::file_ext(name)
@@ -35,7 +35,7 @@ derive_atlas_name <- function(filepath) {
 #' @return "left", "right", or the default value
 #' @noRd
 detect_hemi <- function(label_name, strict = FALSE, default = NA_character_) {
-  if (is.na(label_name) || label_name == "") {
+  if (length(label_name) != 1L || is.na(label_name) || !nzchar(label_name)) {
     return(default)
   }
 

--- a/R/utils_snapshot.R
+++ b/R/utils_snapshot.R
@@ -188,8 +188,7 @@ run_cmd <- function(cmd, verbose = get_verbose(), no_ui = FALSE) {
 get_contours <- function(
   raster_object,
   max_val = 255,
-  vertex_size_limits = c(3 * 10^6, 3 * 10^7),
-  verbose = get_verbose() # nolint: object_usage_linter
+  vertex_size_limits = c(3 * 10^6, 3 * 10^7)
 ) {
   rlang::check_installed("terra", reason = "for contour extraction")
   mx <- terra::global(raster_object, fun = "max", na.rm = TRUE)[1, 1]

--- a/tests/testthat/test-atlas_cerebellar.R
+++ b/tests/testthat/test-atlas_cerebellar.R
@@ -2305,6 +2305,23 @@ describe("download_suit_xfm download failure", {
 })
 
 
+describe("resample_trilinear", {
+  it("skips NaN voxel coordinates instead of erroring", {
+    result <- numeric(2)
+    vox_coords <- rbind(c(NaN, NaN, NaN), c(2, 2, 2))
+    mni_arr <- array(1, dim = c(3, 3, 3))
+
+    expect_message(
+      out <- resample_trilinear(result, vox_coords, mni_arr, c(3, 3, 3)),
+      "Trilinear interpolation"
+    )
+
+    expect_identical(out[1], 0)
+    expect_identical(out[2], 1, tolerance = 1e-8)
+  })
+})
+
+
 describe("prepare_suit_resample", {
   it("errors when the input volume is not 3D", {
     skip_if_not_installed("RNifti")
@@ -2577,12 +2594,16 @@ describe("extract_deep_meshes", {
 
 
 describe("build_deep_nucleus_sf polygonisation failure", {
-  it("returns NULL when terra::as.polygons yields no polygons", {
+  it("warns and returns NULL when terra::as.polygons yields no polygons", {
     skip_if_not_installed("terra")
     vol <- array(0L, dim = c(5, 5, 5))
     vol[2, 2, 2] <- 1L
     local_mocked_bindings(as.polygons = function(...) NULL, .package = "terra")
-    expect_null(build_deep_nucleus_sf(vol, 1L, "test"))
+    expect_warning(
+      result <- build_deep_nucleus_sf(vol, 1L, "test"),
+      "Could not polygonise"
+    )
+    expect_null(result)
   })
 })
 

--- a/tests/testthat/test-atlas_geometry.R
+++ b/tests/testthat/test-atlas_geometry.R
@@ -808,6 +808,28 @@ describe("simplify_sf_topology", {
     expect_identical(nrow(result), 3L)
     expect_false(".view_group" %in% names(result))
   })
+
+  it("does not leak .view_group when filenm data forms a single group", {
+    poly_a <- sf::st_polygon(list(matrix(
+      c(0, 0, 1, 0, 1, 1, 0, 1, 0, 0),
+      ncol = 2,
+      byrow = TRUE
+    )))
+    poly_b <- sf::st_polygon(list(matrix(
+      c(10, 10, 11, 10, 11, 11, 10, 11, 10, 10),
+      ncol = 2,
+      byrow = TRUE
+    )))
+    sf_data <- sf::st_sf(
+      label = c("a", "b"),
+      filenm = c("lateral_1.png", "lateral_2.png"),
+      geometry = sf::st_sfc(poly_a, poly_b)
+    )
+
+    result <- simplify_sf_topology(sf_data, keep = 0.5)
+
+    expect_false(".view_group" %in% names(result))
+  })
 })
 
 

--- a/tests/testthat/test-atlas_repo.R
+++ b/tests/testthat/test-atlas_repo.R
@@ -410,6 +410,24 @@ describe("rstudioapi_available", {
 })
 
 
+describe("replace_template_placeholders", {
+  it("skips files under .git", {
+    tmp <- withr::local_tempdir()
+    dir.create(file.path(tmp, ".git"))
+    writeLines("{GGSEG}", file.path(tmp, ".git", "config"))
+    writeLines("{GGSEG}", file.path(tmp, "DESCRIPTION"))
+
+    expect_message(
+      replace_template_placeholders(tmp, "myatlas"),
+      "Replaced template placeholders"
+    )
+
+    expect_identical(readLines(file.path(tmp, ".git", "config")), "{GGSEG}")
+    expect_identical(readLines(file.path(tmp, "DESCRIPTION")), "myatlas")
+  })
+})
+
+
 describe("template_replace error handling", {
   it("returns NULL and warns for unreadable files", {
     result <- expect_warnings(

--- a/tests/testthat/test-atlas_tracts.R
+++ b/tests/testthat/test-atlas_tracts.R
@@ -19,6 +19,20 @@ describe("create_tract_from_tractography", {
     expect_identical(nrow(atlas$data$centerlines), 2L)
   })
 
+  it("errors when tube_segments is less than 3", {
+    tracts <- list(cst_left = matrix(c(1:20, rep(0, 40)), ncol = 3))
+
+    expect_error(
+      create_tract_from_tractography(
+        input_tracts = tracts,
+        tube_segments = 2,
+        steps = 1,
+        verbose = FALSE
+      ),
+      "must be a single integer"
+    )
+  })
+
   it("warns about deprecated views argument and delegates to slabs", {
     tracts <- list(
       cst_left = matrix(c(1:20, rep(0, 40)), ncol = 3),

--- a/tests/testthat/test-atlas_wholebrain.R
+++ b/tests/testthat/test-atlas_wholebrain.R
@@ -2543,6 +2543,35 @@ describe("wholebrain_prepare_subcortical_volume left-high orientation", {
     expect_true(10L %in% arr)
     expect_true(any(arr %in% c(3L, 42L)))
   })
+
+  it("splits cortex at the 1-based midline voxel", {
+    skip_if_not_installed("RNifti")
+    # 5 cortical voxels along x (3x3 in y/z so read_volume keeps it 3D);
+    # world_x = voxel_x - 2, so the world origin sits at 0-based voxel 2
+    # (1-based voxel 3).
+    arr <- array(1000L, dim = c(5, 3, 3))
+    nii <- RNifti::asNifti(arr)
+    m <- diag(4)
+    m[1, 4] <- -2
+    RNifti::sform(nii) <- structure(m, code = 2L)
+    vol_file <- withr::local_tempfile(fileext = ".nii.gz")
+    RNifti::writeNifti(nii, vol_file)
+    out_file <- withr::local_tempfile(fileext = ".nii.gz")
+
+    wholebrain_prepare_subcortical_volume(
+      input_volume = vol_file,
+      subcortical_idx = integer(0),
+      cortical_idx = 1000L,
+      output_file = out_file
+    )
+
+    arr_out <- as.array(RNifti::readNifti(out_file))
+    # Midline is 1-based voxel 3: x-slices 1-3 left (3L), 4-5 right (42L),
+    # each slice holding 3x3 = 9 voxels. The pre-fix 0-based midline (2)
+    # would have given 18 left / 27 right.
+    expect_identical(sum(arr_out == 3L), 27L)
+    expect_identical(sum(arr_out == 42L), 18L)
+  })
 })
 
 

--- a/tests/testthat/test-mesh_projection.R
+++ b/tests/testthat/test-mesh_projection.R
@@ -123,6 +123,18 @@ describe("build_vertex_label_vector", {
     expect_identical(labels, c("lh_a", NA_character_, NA_character_))
   })
 
+  it("skips NA labels without erroring", {
+    vertices_df <- data.frame(
+      label = c("lh_a", NA_character_),
+      vertices = I(list(0L, 1L)),
+      stringsAsFactors = FALSE
+    )
+
+    labels <- build_vertex_label_vector(vertices_df, 3L, "lh")
+
+    expect_identical(labels, c("lh_a", NA_character_, NA_character_))
+  })
+
   it("drops out-of-range vertex indices", {
     vertices_df <- data.frame(
       label = "lh_a",

--- a/tests/testthat/test-read_write.R
+++ b/tests/testthat/test-read_write.R
@@ -179,6 +179,25 @@ describe("read_lut", {
 
     expect_named(result, c("idx", "label", "R", "G", "B", "A"))
   })
+
+  it("warns about unparseable data lines but keeps comments silent", {
+    tmp <- withr::local_tempfile(fileext = ".txt")
+    writeLines(
+      c(
+        "# a comment line",
+        "  0  Unknown          0   0   0   0",
+        "this is not a valid lut row",
+        "  1  Region1        205 130 176   0"
+      ),
+      tmp
+    )
+
+    expect_warning(
+      result <- read_lut(tmp),
+      "Skipped 1 unparseable line"
+    )
+    expect_identical(nrow(result), 2L)
+  })
 })
 
 
@@ -232,6 +251,13 @@ describe("write_lut", {
 
     content <- readLines(tmp)
     expect_true(all(nchar(content) < 60))
+  })
+
+  it("errors when input is not a valid LUT", {
+    expect_error(
+      write_lut(data.frame(a = 1, b = 2), withr::local_tempfile()),
+      "must be a valid LUT"
+    )
   })
 })
 
@@ -443,6 +469,72 @@ describe("read_dpv", {
     expect_named(result$vertices, c("x", "y", "z"))
     expect_named(result$faces, c("i", "j", "k"))
     expect_identical(as.numeric(result$faces[1, ]), c(0, 1, 2))
+  })
+
+  it("returns zero faces (not reversed rows) when n_faces is 0", {
+    tmp <- withr::local_tempfile(fileext = ".dpv")
+    writeLines(
+      c(
+        "#!ascii",
+        "2 0",
+        "0 0 0 0",
+        "1 1 1 0"
+      ),
+      tmp
+    )
+
+    result <- read_dpv(tmp)
+
+    expect_identical(nrow(result$vertices), 2L)
+    expect_identical(nrow(result$faces), 0L)
+  })
+
+  it("errors when the header counts cannot be parsed", {
+    tmp <- withr::local_tempfile(fileext = ".dpv")
+    writeLines(c("#!ascii", "not numbers", "0 0 0 0"), tmp)
+
+    expect_error(read_dpv(tmp), "Could not read vertex/face counts")
+  })
+})
+
+
+describe("extract_vertex_regions", {
+  it("merges unlabeled vertices into an existing 'unknown' region", {
+    vertex_codes <- c(0L, 0L, 5L, 99L)
+    regions <- data.frame(
+      code = c(0L, 5L),
+      name = c("unknown", "regionA"),
+      colour = c("#000000", "#FF0000"),
+      stringsAsFactors = FALSE
+    )
+
+    result <- extract_vertex_regions(vertex_codes, regions, "left", "lh")
+
+    labels <- vapply(result, function(d) d$label, character(1))
+    expect_identical(sum(labels == "lh_unknown"), 1L)
+
+    unknown_row <- result[[which(labels == "lh_unknown")]]
+    expect_setequal(unknown_row$vertices[[1]], c(0L, 1L, 3L))
+  })
+})
+
+
+describe("cifti_label_regions", {
+  it("warns and uses the first map when several are present", {
+    map <- data.frame(
+      Key = 0:1,
+      Label = c("a", "b"),
+      Red = c(0, 1),
+      Green = c(0, 1),
+      Blue = c(0, 1)
+    )
+    cii <- list(meta = list(cifti = list(labels = list(map, map))))
+
+    expect_warning(
+      res <- cifti_label_regions(cii),
+      "2 label maps"
+    )
+    expect_identical(res$name, c("a", "b"))
   })
 })
 

--- a/tests/testthat/test-snapshots.R
+++ b/tests/testthat/test-snapshots.R
@@ -223,6 +223,15 @@ describe("volume_projection with start/end", {
 
     expect_identical(max(proj), 0)
   })
+
+  it("errors when end is before start instead of reversing the slab", {
+    vol <- array(0, dim = c(10, 10, 10))
+
+    expect_error(
+      volume_projection(vol, "axial", start = 7, end = 3),
+      "before start"
+    )
+  })
 })
 
 

--- a/tests/testthat/test-subcortical_geometry.R
+++ b/tests/testthat/test-subcortical_geometry.R
@@ -303,6 +303,30 @@ describe("read_fs_surface", {
       "Failed to read surface file"
     )
   })
+
+  it("surfaces the underlying conversion error in the abort", {
+    local_mocked_bindings(
+      surf2asc = function(...) stop("bad QUAD header"),
+      read_dpv = function(...) stop("no file"),
+      get_verbose = function() FALSE
+    )
+
+    orig_require <- base::requireNamespace
+    local_mocked_bindings(
+      requireNamespace = function(pkg, ...) {
+        if (pkg == "freesurferformats") {
+          return(FALSE)
+        }
+        orig_require(pkg, ...)
+      },
+      .package = "base"
+    )
+
+    expect_error(
+      read_fs_surface("test_surface"),
+      "bad QUAD header"
+    )
+  })
 })
 
 

--- a/tests/testthat/test-subcortical_steps.R
+++ b/tests/testthat/test-subcortical_steps.R
@@ -157,6 +157,58 @@ describe("subcort_create_meshes", {
     expect_length(result, 1)
     expect_named(result, "Right-Putamen")
   })
+
+  it("passes the requested verbose level through to tessellate_label", {
+    .cap$tess_verbose <- NULL
+    mock_mesh <- list(
+      vertices = list(x = 1:3, y = 1:3, z = 1:3),
+      faces = list(i = 1, j = 2, k = 3)
+    )
+    local_mocked_bindings(
+      tessellate_label = function(..., verbose) {
+        .cap$tess_verbose <- verbose
+        mock_mesh
+      },
+      progressor = function(...) function(...) NULL,
+      future_map2 = mock_future_map2,
+      furrr_options = function(...) list(),
+      center_meshes = function(x) x
+    )
+
+    colortable <- data.frame(
+      idx = 10,
+      label = "Left-Putamen",
+      stringsAsFactors = FALSE
+    )
+    dirs <- list(meshes = withr::local_tempdir())
+
+    expect_message(
+      subcort_create_meshes("fake.mgz", colortable, dirs, FALSE, 2L, NULL),
+      "Created 1 mesh"
+    )
+    expect_identical(.cap$tess_verbose, 2L)
+  })
+})
+
+
+describe("subcort_decimate_meshes", {
+  it("reports NA%, not NaN%, when all meshes have zero faces", {
+    empty_meshes <- list(
+      a = list(
+        faces = data.frame(
+          i = integer(0),
+          j = integer(0),
+          k = integer(0)
+        )
+      )
+    )
+    local_mocked_bindings(decimate_mesh = function(m, percent) m)
+
+    expect_messages(
+      subcort_decimate_meshes(empty_meshes, decimate = 0.5, verbose = TRUE),
+      "\\(NA%\\)"
+    )
+  })
 })
 
 

--- a/tests/testthat/test-tract_geometry.R
+++ b/tests/testthat/test-tract_geometry.R
@@ -218,6 +218,15 @@ describe("compute_parallel_transport_frames", {
       expect_identical(sum(n * b), 0, tolerance = 1e-6)
     }
   })
+
+  it("does not produce NaN frames when the first segment is degenerate", {
+    curve <- rbind(c(0, 0, 0), c(0, 0, 0), c(1, 0, 0), c(2, 0, 0))
+
+    frames <- compute_parallel_transport_frames(curve)
+
+    expect_false(any(is.nan(frames$normals)))
+    expect_false(any(is.nan(frames$binormals)))
+  })
 })
 
 

--- a/tests/testthat/test-tract_steps.R
+++ b/tests/testthat/test-tract_steps.R
@@ -284,13 +284,12 @@ describe("tract_create_snapshots", {
     )
 
     centerlines_df <- data.frame(label = "t1", stringsAsFactors = FALSE)
-    streamlines_data <- list(t1 = list(matrix(1:9, ncol = 3)))
+    centerlines_df$points <- list(matrix(1:9, ncol = 3))
     dirs <- list(snapshots = withr::local_tempdir())
 
     expect_messages(
       {
         result <- tract_create_snapshots(
-          streamlines_data,
           centerlines_df,
           "fake_aseg.mgz",
           NULL,
@@ -348,11 +347,10 @@ describe("tract_create_snapshots", {
     )
 
     centerlines_df <- data.frame(label = "t1", stringsAsFactors = FALSE)
-    streamlines_data <- list(t1 = list(matrix(1:9, ncol = 3)))
+    centerlines_df$points <- list(matrix(1:9, ncol = 3))
     dirs <- list(snapshots = withr::local_tempdir())
 
     result <- tract_create_snapshots(
-      streamlines_data,
       centerlines_df,
       "fake_aseg.mgz",
       custom_slabs,
@@ -405,13 +403,10 @@ describe("tract_create_snapshots", {
     )
 
     centerlines_df <- data.frame(label = "t1", stringsAsFactors = FALSE)
-    streamlines_data <- list(
-      t1 = list(matrix(1:9, ncol = 3), matrix(10:18, ncol = 3))
-    )
+    centerlines_df$points <- list(matrix(1:9, ncol = 3))
     dirs <- list(snapshots = withr::local_tempdir())
 
     result <- tract_create_snapshots(
-      streamlines_data,
       centerlines_df,
       "fake_aseg.mgz",
       NULL,

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -525,7 +525,7 @@ describe("preview_atlas", {
     expect_match(.cap$prompts[1], "3D preview")
   })
 
-  it("handles 3D errors gracefully", {
+  it("warns on 3D errors instead of failing silently", {
     atlas <- list(
       type = "cortical",
       data = list(sf = NULL, vertices = TRUE, meshes = NULL)
@@ -540,9 +540,10 @@ describe("preview_atlas", {
       .package = "ggseg3d"
     )
 
-    invisible(capture.output({
-      result <- preview_atlas(atlas)
-    }))
+    expect_message(
+      result <- preview_atlas(atlas),
+      "3D preview failed"
+    )
     expect_identical(result, atlas)
   })
 

--- a/tests/testthat/test-utils_atlas.R
+++ b/tests/testthat/test-utils_atlas.R
@@ -1,4 +1,12 @@
 describe("detect_hemi", {
+  it("returns the default for non-scalar input instead of erroring", {
+    expect_identical(
+      detect_hemi(c("Left-x", "Right-y")),
+      NA_character_
+    )
+    expect_identical(detect_hemi(character(0)), NA_character_)
+  })
+
   it("detects left from prefix", {
     expect_identical(detect_hemi("Left-Thalamus"), "left")
     expect_identical(detect_hemi("left_amygdala"), "left")
@@ -324,9 +332,13 @@ describe("derive_atlas_name", {
     expect_identical(derive_atlas_name("lh.myatlas.label.gii"), "myatlas")
   })
 
-  it("aborts when no input file is provided", {
-    expect_error(derive_atlas_name(character(0)), "No input file")
-    expect_error(derive_atlas_name(NA), "No input file")
+  it("aborts for missing or non-scalar input", {
+    expect_error(derive_atlas_name(character(0)), "single input file")
+    expect_error(derive_atlas_name(NA), "single input file")
+    expect_error(
+      derive_atlas_name(c("a.nii", "b.nii")),
+      "single input file"
+    )
   })
 })
 


### PR DESCRIPTION
## Summary

Stacked on top of #103 (base branch: `fix/review-2026-07-24`). Resolves the **Suggestion** and **Noted** findings from the full-codebase review, each with a regression test. Purely additive robustness/correctness work — no changes to the blocking/required fixes in #103.

**Rebase note:** once #103 merges, this will be rebased onto `main`.

### Correctness / consistency
- Tract 2D projections now reuse the 3D tube's centerline (built with the configured `n_points`/`centerline_method`) rather than recomputing a different 50-point mean centerline.
- `create_wholebrain_from_volume()` splits cortex at the correct 1-based midline voxel (was off by one).
- Annotation `unknown` regions merge instead of producing a duplicate label.
- `read_dpv()` uses `seq_len()` for faces (no reversed slab when `n_faces == 0`).

### Robustness — clear errors/warnings instead of silent failure or crashes
- `read_lut()` warns on malformed lines; `write_lut()` validates input; `read_lut()`/`read_dpv()` abort clearly on unreadable input.
- CIFTI files with multiple label maps warn.
- Contour extraction, trilinear resampling (`NaN` coords), parallel-transport frames (degenerate leading segment), and vertex-label building (`NA` label) no longer crash; deep-nucleus polygonisation failures are reported.
- `read_fs_surface()` surfaces the underlying conversion error; `preview_atlas()` warns on 3D render failure.
- `tube_segments` validated (integer ≥ 3); `volume_projection()` errors when `end < start`; `detect_hemi()`/`derive_atlas_name()` handle non-scalar input.

### Cleanups
- `read_tck()` collects points once (no O(n²) `rbind` growth).
- Subcortical tessellation honors the requested verbose level in parallel workers; the decimation summary prints `NA%` (not `NaN%`) for zero-face meshes.
- `simplify_sf_topology()` never leaks its temporary grouping column.
- `get_contours()` drops its unused `verbose` parameter.
- `setup_atlas_repo()` skips template `.git` internals and reports failed file copies/renames.

### Deferred (documented in the review)
- Continuous-map `0.0` medial-wall detection (needs an `mri_vol2surf` mask — pipeline change).
- Big-endian `.trk` detection (rare format, non-trivial).
- The `nocov` template-download temp-dir cleanup (needs signalling to avoid deleting the bundled fallback).

## Test Plan
- `devtools::test()` (parallel) — **0 failures**, only FreeSurfer/ImageMagick skips
- `lintr::lint_package()` — 0 lints; `air format` — no changes
- `goodpractice`: cyclomatic complexity ≤ 15 (extracted `trilinear_sample`/`read_trk_streamline`/`tck_points_to_matrix`), `tidyverse_export_order` passes, spelling clean
- 30+ new/updated regression tests across the affected files

Review conducted with the [critical-code-reviewer skill](https://github.com/posit-dev/skills/blob/main/posit-dev/critical-code-reviewer/SKILL.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)