### PR TITLE
chore: add dev script to reproduce the CI good-practice gate locally

### DIFF
--- a/dev/check-like-ci.R
+++ b/dev/check-like-ci.R
@@ -1,0 +1,89 @@
+# Reproduce the CI good-practice gate locally, before pushing.
+#
+#   Rscript dev/check-like-ci.R          # lintr checks only (~1 min)
+#   Rscript dev/check-like-ci.R --full   # every check CI runs (slow)
+#
+# Why this exists: `lintr::lint_package()` uses the package .lintr, which is
+# lintr's default linter set. The `code-quality / good-practice` job in
+# ggsegverse/.github runs goodpractice, whose linter set is far broader. Code
+# can be locally clean and still hard-fail CI -- that happened twice in one
+# session (`<<-` via undesirable_operator_linter, and a non-fixed grepl() via
+# fixed_regex_linter), each costing a ~50 minute CI cycle.
+#
+# This calls goodpractice itself rather than reimplementing its linting with
+# lint_package(). That matters: a lint_package() reimplementation over-reports,
+# flagging vignette library() calls and testthat assignment idioms that
+# goodpractice does not flag. Only running the real thing matches CI.
+#
+# The default mode requests only the lintr checks, so goodpractice runs just
+# its lintr prep and skips the slow rcmdcheck prep. Both lintr failures that
+# have bitten this package would have been caught in that mode. Use --full
+# before a release, when the rcmdcheck- and roxygen-based checks matter too.
+
+if (!requireNamespace("goodpractice", quietly = TRUE)) {
+  stop("install.packages('goodpractice')")
+}
+
+full <- "--full" %in% commandArgs(trailingOnly = TRUE)
+
+# Mirrors the `checks <- setdiff(...)` block in
+# ggsegverse/.github/.github/workflows/code-quality.yaml. Keep in step with it.
+excluded <- c(
+  "lintr_strings_as_factors_linter",
+  "tidyverse_r_file_names",
+  "lintr_duplicate_argument_linter",
+  "lintr_scalar_in_linter",
+  "lintr_unnecessary_lambda_linter",
+  "urlchecker_ok",
+  "urlchecker_no_redirects",
+  "covr",
+  "complexity_function_length",
+  "tidyverse_test_file_names"
+)
+
+checks <- setdiff(
+  union(goodpractice::all_checks(), goodpractice::tidyverse_checks()),
+  excluded
+)
+
+if (!full) {
+  checks <- grep("^lintr_|^tidyverse_.*_linter$", checks, value = TRUE)
+}
+
+cat(
+  "Running",
+  length(checks),
+  if (full) "checks (full)" else "lintr checks",
+  "\n\n"
+)
+
+result <- goodpractice::gp(checks = checks)
+failed <- goodpractice::failed_checks(result)
+
+# These two fail only for local-environment reasons and are not real: CI
+# installs tinytex, and .impeccable/ is gitignored so CI never sees it.
+local_only <- c(
+  "rcmdcheck_can_convert_rd_to_pdf_2",
+  "rcmdcheck_hidden_files_and_directories"
+)
+noise <- intersect(failed, local_only)
+real <- setdiff(failed, local_only)
+
+if (length(noise)) {
+  cat("Ignored (local environment only):\n")
+  cat(paste0("  - ", noise, collapse = "\n"), "\n\n")
+}
+
+if (length(real) == 0) {
+  cat("Clean -- this would pass the CI good-practice gate.\n")
+} else {
+  cat("FAILED:", length(real), "\n\n")
+  for (f in real) {
+    cat("-", f, "\n")
+    pos <- result$checks[[f]]$positions
+    for (p in utils::head(pos, 10)) {
+      cat(sprintf("    %s:%s  %s\n", p$filename, p$line_number, trimws(p$line)))
+    }
+  }
+  quit(status = 1L)
+}


### PR DESCRIPTION
Follow-up to the atlas template work, closing the local-vs-CI gap that bit that stack twice.

## The problem

`lintr::lint_package()` uses the package `.lintr`, which is lintr's default linter set. The `code-quality / good-practice` job in `ggsegverse/.github` runs goodpractice, whose linter set is far broader. **Code can be locally clean and still hard-fail CI.**

That is not hypothetical — it happened twice while landing #103–#108:

| Defect | Local `lint_package()` | CI good-practice |
|---|---|---|
| `surf2asc_error <<- ...` | clean | `lintr_undesirable_operator_linter` |
| `grepl("file LICENSE", x)` | clean | `lintr_fixed_regex_linter` |

Each cost a full CI cycle — R-devel compiles deps from source, so ~50 minutes to learn something a local check could have told us in one.

## Approach, and one I rejected

My first attempt reimplemented the gate: pull `goodpractice:::linters_to_lint()` and feed it to `lintr::lint_package()`. It looked right and was wrong — it over-reports. `lint_package()` flagged 30 `library()` calls in vignettes and 18 instances of the standard testthat idiom:

```r
expect_warning(result <- read_lut(tmp), "...")
```

goodpractice flags none of those. Rather than encode a guess about why, the script calls `goodpractice::gp()` directly, so it matches CI by construction and cannot drift as goodpractice evolves.

(Worth recording: that testthat idiom cannot be rewritten as `result <- expect_warning(read_lut(tmp))` — expectations return the *condition*, not the value, so the rewrite silently breaks the test. I checked before assuming.)

## Usage

```
Rscript dev/check-like-ci.R          # linter checks only, ~75s
Rscript dev/check-like-ci.R --full   # everything CI runs, slow
```

Default mode requests only the linter checks, so goodpractice runs its lintr prep and skips the slow rcmdcheck prep. Both real failures above are caught in that mode.

The exclusion list mirrors the `checks <- setdiff(...)` block in the shared workflow and is the one part that needs manual sync — deliberately kept short, with a pointer to the source of truth.

Two checks that fail only for local reasons are reported as noise rather than failures, so the signal stays clean: `can_convert_rd_to_pdf_2` (no LaTeX locally; CI installs tinytex) and `hidden_files_and_directories` (a gitignored `.impeccable/` CI never sees).

## Test plan

Negative test — reintroduced both original defects and re-ran:

```
- lintr_fixed_regex_linter
    tests/testthat/test-atlas_repo.R:258  grepl("file LICENSE", license),
- lintr_undesirable_operator_linter
    R/subcortical_geometry.R:287  ... surf2asc_err <<- conditionMessage(e) ...
```

Both reported with file and line, exit status 1. On the clean tree it reports clean and exits 0. `air` and `lintr` clean. `dev/` is already `.Rbuildignore`d, so nothing ships.

## Not done here

This helps one repo. The underlying config lives in `ggsegverse/.github` and every package in the org has the same gap. If this shape is right, it belongs there rather than copied per-repo — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)