### PR TITLE
fix(pkgdown): index the new github actions helpers

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -91,12 +91,15 @@ reference:
     desc: Functions to manipulate and manage brain atlases
     contents:
       - starts_with("atlas_")
+      - -atlas_github_actions
 
   - title: Atlas Repository
     desc: Create and manage ggseg atlas packages
     contents:
       - setup_atlas_repo
       - setup_sitrep
+      - use_atlas_github_actions
+      - atlas_github_actions
 
   - title: Color Tables
     desc: Read, write, and manipulate FreeSurfer color tables


### PR DESCRIPTION
Fixes the `pkgdown` failure on `main` after #111.

```
Error in `build_reference_index()`:
! In _pkgdown.yml, 1 topic missing from index: "use_atlas_github_actions".
```

pkgdown hard-errors when an exported topic is not reachable from the reference index, and #111 added `use_atlas_github_actions()` without listing it. My mistake.

Only *one* topic was reported because `starts_with("atlas_")` happened to sweep up `atlas_github_actions` — into **Atlas Manipulation**, described as "functions to manipulate and manage brain atlases". A helper that lists CI workflow names does not belong there; it was hidden rather than placed. Both helpers now sit in **Atlas Repository** next to `setup_atlas_repo()`, with the stray match excluded from the manipulation section.

## Why this reached main

`pkgdown` triggers on `push` and `release` only, never on `pull_request`, so no PR check could have caught it. Same structural gap I hit earlier in this series with `code-quality` on stacked PRs: a workflow that does not run on PRs cannot gate a PR.

## Verification

`pkgdown::check_pkgdown()` cannot run locally — it inspects the `.qmd` vignettes and quarto is not installed here. Instead I confirmed the exclusion syntax against pkgdown's own `select_topics()`, which builds signed indexes and applies `setdiff` for `-` entries. Since the first entry in the section is positive (`starts_with`), selection starts empty, adds the `atlas_*` matches, then subtracts the excluded one — so the section keeps everything except `atlas_github_actions`, which is claimed explicitly elsewhere.

I also wrote a throwaway index checker and it over-reported, flagging the deprecated `read_ctab`/`subcortical_views` aliases as missing; it only read `\name{}` and ignored `\alias{}`, which pkgdown matches on. Not worth keeping, but worth saying that its extra findings were artefacts, not real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)