### PR TITLE
ci: gate pull requests with pkgdown and unfiltered lint/coverage

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,8 +1,9 @@
 on:
   push:
     branches: [main, master]
+  # No branches filter: with one, a PR stacked on another branch skips this
+  # check entirely and only gets gated once it is retargeted at main.
   pull_request:
-    branches: [main, master]
 
 name: code-quality
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,6 +1,11 @@
 on:
   push:
     branches: [main, master]
+  # Builds on every PR so a broken reference index or vignette fails review
+  # rather than main. The reusable guards its deploy step with
+  # `github.event_name != 'pull_request'`, so PRs build without publishing.
+  # No branches filter: a PR stacked on another branch needs gating too.
+  pull_request:
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,8 +1,11 @@
 on:
   push:
     branches: [main, master]
+  # No branches filter: with one, a PR stacked on another branch skips this
+  # check entirely and only gets gated once it is retargeted at main. The
+  # reusable only commits the badge on main/master, so PRs measure without
+  # publishing.
   pull_request:
-    branches: [main, master]
 
 name: test-coverage
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggseg.extra
 Title: Create Brain Atlases for the 'ggsegverse' Plotting Ecosystem
-Version: 1.9.9.9010
+Version: 1.9.9.9011
 Authors@R: c(
     person(
         given = "Athanasia Mo",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# ggseg.extra 1.9.9.9011
+
+## Minor improvements and fixes
+
+- Workflows written by `use_atlas_github_actions()` now run on pull requests.
+  `pkgdown` previously had no pull request trigger at all, so a broken
+  reference index or vignette could only fail after merging; `code-quality`
+  filtered pull requests to those targeting `main`, so a stacked pull request
+  skipped linting entirely. Neither publishes from a pull request: the shared
+  workflows guard the pkgdown deploy on `github.event_name`, and the coverage
+  badge and README commits on `github.ref`.
+
 # ggseg.extra 1.9.9.9010
 
 ## New features

--- a/inst/templates/workflows/code-quality.yaml
+++ b/inst/templates/workflows/code-quality.yaml
@@ -1,8 +1,9 @@
 on:
   push:
     branches: [main, master]
+  # No branches filter: with one, a PR stacked on another branch skips this
+  # check entirely and only gets gated once it is retargeted at main.
   pull_request:
-    branches: [main, master]
 
 name: code-quality
 

--- a/inst/templates/workflows/pkgdown.yaml
+++ b/inst/templates/workflows/pkgdown.yaml
@@ -1,6 +1,10 @@
 on:
   push:
     branches: [main, master]
+  # Builds on every PR so a broken reference index or vignette fails review
+  # rather than main. The reusable guards its deploy step with
+  # `github.event_name != 'pull_request'`, so PRs build without publishing.
+  pull_request:
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Closes the two trigger gaps that let broken changes reach `main` during the atlas template series.

## The gaps

| workflow | pull_request trigger | consequence |
|---|---|---|
| `R-CMD-check` | unfiltered | fine — the only one that gated stacked PRs |
| `code-quality` | `branches: [main, master]` | **skipped** on stacked PRs |
| `test-coverage` | `branches: [main, master]` | **skipped** on stacked PRs |
| `pkgdown` | none | **never** gated a PR |

Both gaps caused real failures in this series:

- **#111 shipped an unindexed export** and turned `main` red. pkgdown hard-errors when an exported topic is missing from the reference index, but it only ran on `push`, so no PR check could catch it (fixed after the fact in #113).
- **#104 and #105 were never linted** for most of their life. Only `R-CMD-check` ran, because it is the one workflow whose `pull_request` trigger had no `branches` filter. An `undesirable_operator_linter` failure surfaced only once the PR was retargeted at `main` — and a base change alone does not re-fire workflows, so it took a force-push to notice.

## The fix

Remove the `branches` filter from `code-quality` and `test-coverage`; add an unfiltered `pull_request` to `pkgdown`. Triggers must live in the caller stub — a `workflow_call` reusable cannot declare its own — so this is a stub-level change, applied both to this package's workflows and to the stubs `use_atlas_github_actions()` writes, so atlas packages get the gating too.

## Nothing publishes from a PR

Audited every publishing step in the shared workflows rather than assuming:

| workflow | publishing step | guard |
|---|---|---|
| pkgdown | `Deploy to GitHub pages 🚀` | `github.event_name != 'pull_request'` |
| test-coverage | `Commit coverage badge` | `github.ref == refs/heads/main \|\| master` |
| render-readme | `Commit and push` | `github.ref == refs/heads/main \|\| master` |
| code-quality | — | no publishing steps |
| R-CMD-check | — | no publishing steps |

The `github.ref` guards are doubly safe: on a `pull_request` event `github.ref` is `refs/pull/N/merge`, never a branch name. `code-quality` does post PR comments, which is the point of it on a PR and not a repo write.

Workflows that genuinely publish — `update-codemeta`, `dev-version-bump`, `release-on-version`, `neuroconductor-release`, `rhub` — are untouched and remain push/dispatch only.

## Test plan

This PR is its own test: `pkgdown` should appear in its checks for the first time and build without deploying. All five changed files parse as valid YAML with `pull_request` present and no `branches` filter. `air`, `lintr`, spelling and the `use_atlas_github_actions()` tests all clean locally.

The one cost is CI time — pkgdown adds roughly six minutes per PR. Worth it against a red `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)