### PR TITLE
chore: scaffold uses ggseg::brain_test_plot() + dev ggseg Remote

### DIFF
--- a/inst/templates/atlas-fallback/DESCRIPTION
+++ b/inst/templates/atlas-fallback/DESCRIPTION
@@ -22,6 +22,8 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     vdiffr
+Remotes:
+    ggsegverse/ggseg
 URL: https://github.com/ggsegverse/PKGNAME
 BugReports: https://github.com/ggsegverse/PKGNAME/issues
 Roxygen: list(markdown = TRUE)

--- a/inst/templates/atlas-fallback/tests/testthat/test-data.R
+++ b/inst/templates/atlas-fallback/tests/testthat/test-data.R
@@ -6,21 +6,11 @@ describe("ATLASNAME", {
 
   it("renders with ggseg", {
     skip_if_not_installed("ggseg")
-    skip_if_not_installed("ggplot2")
     skip_if_not_installed("vdiffr")
-    p <- ggplot2::ggplot() +
-      ggseg::geom_brain(
-        atlas = ATLASNAME(),
-        mapping = ggplot2::aes(fill = label),
-        position = ggseg::position_brain(hemi ~ view),
-        show.legend = FALSE
-      ) +
-      ggplot2::scale_fill_manual(
-        values = ATLASNAME()$palette,
-        na.value = "grey"
-      ) +
-      ggplot2::theme_void()
-    vdiffr::expect_doppelganger("ATLASNAME-2d", p)
+    vdiffr::expect_doppelganger(
+      "ATLASNAME-2d",
+      ggseg::brain_test_plot(ATLASNAME())
+    )
   })
 
   it("renders with ggseg3d", {


### PR DESCRIPTION
## Summary
Updates the offline atlas-fallback scaffold (`inst/templates/atlas-fallback/`) to match the ggseg-atlas-template change:
- `tests/testthat/test-data.R` renders via `ggseg::brain_test_plot()`.
- `DESCRIPTION` adds `Remotes: ggsegverse/ggseg` so scaffolded atlases install the dev `ggseg` that provides `brain_test_plot()`.

Required so the template repo`'s `fallback-in-sync` check passes. Scaffold ships twice (template repo + this fallback for `setup_atlas_repo()`); both must be byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)